### PR TITLE
Implement the basics of a DenseOres plugin

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/DenseOres.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/DenseOres.java
@@ -1,0 +1,55 @@
+package com.mcmoddev.basemetals.integration.plugins;
+
+import com.mcmoddev.basemetals.BaseMetals;
+import com.mcmoddev.basemetals.integration.BaseMetalsPlugin;
+import com.mcmoddev.basemetals.util.Config.Options;
+import com.mcmoddev.lib.init.Materials;
+import com.mcmoddev.lib.integration.IIntegration;
+import com.mcmoddev.lib.material.MetalMaterial;
+import com.mcmoddev.lib.util.Oredicts;
+
+@BaseMetalsPlugin(DenseOres.PLUGIN_MODID)
+public class DenseOres extends com.mcmoddev.lib.integration.plugins.DenseOres implements IIntegration {
+
+	private static boolean initDone = false;
+	
+	@Override
+	public void init() {
+		if (initDone || !com.mcmoddev.basemetals.util.Config.Options.enableDenseOres) {
+			return;
+		}
+		
+		registerOres();
+		
+		initDone = true;
+	}
+	
+	/**
+	 * Register all ores that are currently known by the materials registry
+	 * 
+	 * @author Daniel Hazelton &lt;dshadowwolf@gmail.com&gt;
+	 */
+	public static void registerOres() {
+		String [] baseNames = new String[] { "adamantine" , "antimony", "bismuth", "coldiron", "copper", "lead", "mercury", "nickel", "platinum", "silver", "starsteel", "tin", "zinc"};
+		boolean[] baseEnabled = new boolean[] { Options.enableAdamantine, Options.enableAntimony, Options.enableBismuth, Options.enableColdIron, Options.enableCopper, Options.enableLead, Options.enableMercury, Options.enableNickel, Options.enablePlatinum, Options.enableSilver, Options.enableStarSteel, Options.enableTin, Options.enableZinc };
+		for( int i = 0; i < baseNames.length; i++ ) {
+			String ore = baseNames[i];
+			MetalMaterial mat = Materials.getMaterialByName(ore);
+			if( mat != null && baseEnabled[i] ) {
+				String baseMaterial = "stone";
+				switch( ore ) {
+				case "starsteel":
+					baseMaterial = "end_stone";
+					break;
+				case "adamantine":
+				case "coldiron":
+					baseMaterial = "netherrack";
+					break;
+				default:
+					baseMaterial = "stone";
+				}
+				registerOre(String.format("%s_%s", ore, Oredicts.ORE), "basemetals", baseMaterial, 0);
+			}
+		}
+	}	
+}

--- a/src/main/java/com/mcmoddev/basemetals/util/Config.java
+++ b/src/main/java/com/mcmoddev/basemetals/util/Config.java
@@ -79,6 +79,7 @@ public class Config {
 		Options.enableTinkersConstruct = configuration.getBoolean("tinkers_construct_integration", INTEGRATION_CAT, true, "If false, then Base Metals will not try and integrate with Tinkers Construct");
 		Options.enableVeinminer = configuration.getBoolean("veinminer_integration", INTEGRATION_CAT, true, "If false, then Base Metals will not try and integrate with VeinMiner");
 		Options.enableTAIGA = configuration.getBoolean("taiga_integration", INTEGRATION_CAT, true, "Requires that Tinkers' Construct integration also be on. If false, TAIGA provided materials and traits will not be available in Base Metals");
+		Options.enableDenseOres = configuration.getBoolean("denseores", INTEGRATION_CAT, true, "If DenseOres is available, this will allow automatic integration");
 		
 		// METALS
 		Options.enableAdamantine = configuration.getBoolean("EnableAdamantine", MATERIALS_CAT, true, "Enable Adamantine Items and Materials");
@@ -313,6 +314,7 @@ public class Config {
 		public static boolean enablePressurePlate = true;
 		public static boolean enableStairs = true;
 		public static boolean enableWall = true;
+		public static boolean enableDenseOres = true;
 
 		private Options() {
 			throw new IllegalAccessError("Not a instantiable class");

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/DenseOres.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/DenseOres.java
@@ -1,0 +1,47 @@
+package com.mcmoddev.lib.integration.plugins;
+
+import com.mcmoddev.basemetals.BaseMetals;
+import com.mcmoddev.lib.integration.IIntegration;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+
+public class DenseOres implements IIntegration {
+
+	public static final String PLUGIN_MODID = "denseores";
+
+	private static boolean initDone = false;
+
+	@Override
+	public void init() {
+		if (initDone || !com.mcmoddev.basemetals.util.Config.Options.enableDenseOres) {
+			return;
+		}
+
+		initDone = true;
+	}
+
+	/**
+	 * Register a single ore
+	 * 
+	 * @param name Oredictionary name of this ore in its source mod
+	 * @param modID ID of mod that is the source of this ore
+	 * @param underlying One of "stone", "netherrack", "end_stone" or "obsidian" - this determines the background of the dense ore texture 
+	 * @param meta The metadata value for this ore in the source block
+	 * @author Daniel Hazelton &lt;dshadowwolf@gmail.com&gt;
+	 */
+	public static void registerOre(String name, String modID, String underlying, int meta) {
+		BaseMetals.logger.error("Registering %s, baseBlock %s:%s with meta %d and baseBlockTexture blocks/%s", name, modID, name, meta, underlying);
+		NBTTagCompound mess = new NBTTagCompound();
+		mess.setString("baseBlock", String.format("%s:%s", modID, name));
+		mess.setInteger("baseBlockMeta", meta);
+		mess.setString("underlyingBlockTexture", String.format( "blocks/%s", underlying ));
+		// no idea what this does, but it is looked for
+		mess.setInteger("renderType", 0);
+		// this, however, is apparently a name, so...
+		mess.setString("config_entry", String.format("%s %s ore", modID, name));
+		
+		BaseMetals.logger.error("Sending Message for material %s with baseBlock set to %s:%s and meta of %d", name, modID, name, meta);
+		FMLInterModComms.sendMessage("denseores",  "addDenseOre", mess);
+	}
+}


### PR DESCRIPTION
Now pack makers and independent gamers using *metals and DenseOres don't need to create a custom config.
Only implemented in BaseMetals right now, as this has an MMDLib component and implementing for other members of the *metals family need this as a base.