### PR TITLE
Fix the vanilla-material furnace cheese issue

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/init/Recipes.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Recipes.java
@@ -113,6 +113,68 @@ public class Recipes extends com.mcmoddev.lib.init.Recipes {
 				}
 			}
 		}
+		// furnace cheese all the things!
+		for( MetalMaterial mat : Materials.getAllMaterials() ) {
+			if( (mat.ingot) != null && !(mat.ingot instanceof com.mcmoddev.lib.material.IMetalObject) && mat.hasOre ) {
+				if (Options.furnaceCheese) {
+					if( mat.boots != null )
+						GameRegistry.addSmelting(mat.boots, new ItemStack(mat.ingot, 4), 0);
+					
+					if( mat.helmet != null )
+						GameRegistry.addSmelting(mat.helmet, new ItemStack(mat.ingot, 5), 0);
+					
+					if( mat.sword != null )
+						GameRegistry.addSmelting(mat.sword, new ItemStack(mat.ingot, 2), 0);
+
+					if( mat.shovel != null )
+						GameRegistry.addSmelting(mat.shovel, new ItemStack(mat.ingot, 1), 0);
+					
+					if( mat.pickaxe != null )
+						GameRegistry.addSmelting(mat.pickaxe, new ItemStack(mat.ingot, 3), 0);
+
+					if( mat.hoe != null )
+						GameRegistry.addSmelting(mat.hoe, new ItemStack(mat.ingot, 2), 0);
+					
+					if( mat.axe != null )
+						GameRegistry.addSmelting(mat.axe, new ItemStack(mat.ingot, 3), 0);
+					
+					if( mat.leggings != null )
+						GameRegistry.addSmelting(mat.leggings, new ItemStack(mat.ingot, 7), 0);
+					
+					if( mat.chestplate != null )
+						GameRegistry.addSmelting(mat.chestplate, new ItemStack(mat.ingot, 8), 0);
+					
+				} else if (Options.furnace1112) {
+					if( mat.boots != null )
+						GameRegistry.addSmelting(mat.boots, new ItemStack(mat.nugget, 1), 0);
+					
+					if( mat.helmet != null )
+						GameRegistry.addSmelting(mat.helmet, new ItemStack(mat.nugget, 1), 0);
+					
+					if( mat.sword != null )
+						GameRegistry.addSmelting(mat.sword, new ItemStack(mat.nugget, 1), 0);
+
+					if( mat.shovel != null )
+						GameRegistry.addSmelting(mat.shovel, new ItemStack(mat.nugget, 1), 0);
+					
+					if( mat.pickaxe != null )
+						GameRegistry.addSmelting(mat.pickaxe, new ItemStack(mat.nugget, 1), 0);
+
+					if( mat.hoe != null )
+						GameRegistry.addSmelting(mat.hoe, new ItemStack(mat.nugget, 1), 0);
+					
+					if( mat.axe != null )
+						GameRegistry.addSmelting(mat.axe, new ItemStack(mat.nugget, 1), 0);
+					
+					if( mat.leggings != null )
+						GameRegistry.addSmelting(mat.leggings, new ItemStack(mat.nugget, 1), 0);
+					
+					if( mat.chestplate != null )
+						GameRegistry.addSmelting(mat.chestplate, new ItemStack(mat.nugget, 1), 0);
+				}
+			}
+		}		
+
 	}
 
 	private static void initModSpecificRecipes() {

--- a/src/main/java/com/mcmoddev/lib/init/Recipes.java
+++ b/src/main/java/com/mcmoddev/lib/init/Recipes.java
@@ -9,6 +9,7 @@ import com.mcmoddev.lib.material.IMetalObject;
 import com.mcmoddev.lib.util.Oredicts;
 
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.RecipeSorter;
@@ -133,9 +134,9 @@ public abstract class Recipes {
 	}
 
 	protected static void initVanillaRecipes() {
-		// STUB
+		// stub
 	}
-
+	
 	protected static void initGeneralRecipes() {
 
 		for (final MetalMaterial material : Materials.getAllMaterials()) {


### PR DESCRIPTION
Makes sure that vanilla-material furnace cheese recipes are setup. Current code excludes them in one of the checks, this patch does its best to catch them though the tests need some refining, this works for now