### PR TITLE
One major fix and a couple of small ones

### DIFF
--- a/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TCMaterial.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TCMaterial.java
@@ -292,7 +292,7 @@ public class TCMaterial {
      */
     public TCMaterial setMetalMaterial(MetalMaterial mm) {
         this.metalmaterial = mm;
-        return this;
+        return genFromMaterial();
     }
 
     /**

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TinkersConstructRegistry.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TinkersConstructRegistry.java
@@ -9,7 +9,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fml.common.FMLLog;
 import slimeknights.tconstruct.library.MaterialIntegration;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.materials.Material;
@@ -112,7 +111,8 @@ public class TinkersConstructRegistry {
         if( getInstance().isRegistered(n) ) {
             return getInstance().getMaterial(n);
         }
-        return getMaterial(name).setMaterial(material);
+        
+        return getInstance().put(name, new TCMaterial(name, material));
     }
 
     /**
@@ -131,10 +131,9 @@ public class TinkersConstructRegistry {
      */
     private TCCode register(TCMaterial mat) {
 		if (TinkerRegistry.getMaterial(mat.getName().toLowerCase()) != Material.UNKNOWN) {
-			FMLLog.severe("In register() - Material %s already known", mat.getName());
 			return TCCode.MATERIAL_ALREADY_REGISTERED;
 		}
-    	FMLLog.severe("Registering material %s", mat.getName());
+		
     	Boolean hasTraits = !mat.getTraitLocations().isEmpty();
     	
     	if( mat.getMetalMaterial().fluid == null ) {
@@ -173,7 +172,6 @@ public class TinkersConstructRegistry {
 			m.toolforge();
 		}
 
-//		TinkerIntegration.integrationList.add(m);
 		addIntegration(m);
 		m.integrate();
 		return TCCode.SUCCESS;
@@ -187,6 +185,9 @@ public class TinkersConstructRegistry {
         for( Entry<String,TCMaterial> ent : registry.entrySet() ) {
         	// log ent.getKey() - the material name - here ?
         	TCCode rv = register(ent.getValue());
+        	// Either we've had a success or the material is already registered
+        	// in those two cases, we carry on. Otherwise we return the error and
+        	// halt
         	if( rv != TCCode.SUCCESS && rv != TCCode.MATERIAL_ALREADY_REGISTERED ) {
         		return rv;
         	}

--- a/src/main/java/com/mcmoddev/lib/item/ItemMetalShield.java
+++ b/src/main/java/com/mcmoddev/lib/item/ItemMetalShield.java
@@ -8,9 +8,9 @@ import com.mcmoddev.lib.registry.IOreDictionaryEntry;
 import com.mcmoddev.lib.util.Oredicts;
 
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemBanner;
 import net.minecraft.item.ItemShield;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.oredict.OreDictionary;
 
 /**
@@ -71,8 +71,18 @@ public class ItemMetalShield extends ItemShield implements IOreDictionaryEntry, 
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public String getItemStackDisplayName(ItemStack stack) {
-		return I18n.translateToLocal(String.format("%s.name", this.getUnlocalizedName()));
+		String name = String.format("%s.name", this.getUnlocalizedName());
+		if( net.minecraft.util.text.translation.I18n.canTranslate(name) ) {
+			if( stack.getSubCompound("BlockEntityTag", false) != null ) {
+				String colored_name = String.format("%s.%s.name", this.getUnlocalizedName(), ItemBanner.getBaseColor(stack));
+				return net.minecraft.util.text.translation.I18n.translateToLocal(colored_name);
+			} else {
+				return name;
+			}
+		}
+		return name;
 	}
 
 }


### PR DESCRIPTION
From looking at Vanilla, shields can have banners/colors and this gets reflected in their NBT. Dug into the forgeSrc jar to find the name of the Compound Tag that covers this and implemented it, at the same time as flagging the function as containing deprecated calls and that they should be ignored.

The TiC plugin was missing a call to genFromMaterial() in the .setMaterial() call chain and the internal chains should not be using that call chain anyway. That's been fixed on all sides.