### PR TITLE
fix a pair of bad derps

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
@@ -39,6 +39,7 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		registerMaterial(Options.enableAquarium, MaterialNames.AQUARIUM, true, false, "aquadynamic", "jagged", TraitLocations.HEAD, "aquadynamic", TraitLocations.HEAD);
 		registerMaterial(Options.enableBismuth, MaterialNames.BISMUTH, true, false);
 		registerMaterial(Options.enableBrass, MaterialNames.BRASS, true, false, "dense");
+		//registerMaterial(Options.enableBronze, MaterialNames.BRONZE, true, false);
 		registerMaterial(Options.enableColdIron, MaterialNames.COLDIRON, true, false, "freezing");
 		registerMaterial(Options.enableCupronickel, MaterialNames.CUPRONICKEL, true, false);
 		registerMaterial(Options.enableInvar, MaterialNames.INVAR, true, false);

--- a/src/main/java/com/mcmoddev/lib/item/ItemMetalCrackHammer.java
+++ b/src/main/java/com/mcmoddev/lib/item/ItemMetalCrackHammer.java
@@ -113,8 +113,8 @@ public class ItemMetalCrackHammer extends ItemTool implements IMetalObject {
 						int toolDamage;
 						if (Options.crackhammerFullStack) {
 							output.stackSize = targetItem.stackSize;
-							if (item.getItemDamage() < output.stackSize) {
-								output.stackSize = item.getItemDamage();
+							if (item.isItemDamaged() && (item.getItemDamage() < output.stackSize)) {
+									output.stackSize = item.getItemDamage();
 							}
 							toolDamage = output.stackSize;
 						} else {


### PR DESCRIPTION
Derp 1) TiC registers Bronze, period. We can't until we get the TiC event code stuff integrated
Derp 2) Items that are completely undamaged have a 'damage'/'metadata' of 0 - so a completely undamaged crackhammer was always going to fail to do anything. Thanks for tracking down the source of this, Aedda! The logic has been fixed so it now checked if the item is damaged *and* if the damage is less than the stack size before reducing the size of the cracked stack by the amount of damage remaining.