### PR TITLE
Not being able to use coal nuggets as fuel irritated me

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/init/Items.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Items.java
@@ -1,7 +1,9 @@
 package com.mcmoddev.basemetals.init;
 
 import com.mcmoddev.basemetals.util.Config.Options;
+import com.mcmoddev.lib.fuels.FuelRegistry;
 import com.mcmoddev.lib.material.MetalMaterial;
+import com.mcmoddev.lib.util.Oredicts;
 
 import net.minecraft.item.ItemStack;
 
@@ -64,6 +66,10 @@ public class Items extends com.mcmoddev.lib.init.Items {
 			createNugget(material);
 			createPowder(material);
 			createSmallPowder(material);
+			FuelRegistry.addFuel(Oredicts.NUGGETCHARCOAL, 200);
+			FuelRegistry.addFuel(Oredicts.DUSTCHARCOAL, 1600);
+			FuelRegistry.addFuel(Oredicts.DUSTSMALLCHARCOAL, 200);
+			FuelRegistry.addFuel(Oredicts.DUSTTINYCHARCOAL, 200);
 		}
 
 		if (Options.enableCoal) {
@@ -73,6 +79,10 @@ public class Items extends com.mcmoddev.lib.init.Items {
 			createNugget(material);
 			createPowder(material);
 			createSmallPowder(material);
+			FuelRegistry.addFuel(Oredicts.NUGGETCOAL, 200);
+			FuelRegistry.addFuel(Oredicts.DUSTCOAL, 1600);
+			FuelRegistry.addFuel(Oredicts.DUSTSMALLCOAL, 200);
+			FuelRegistry.addFuel(Oredicts.DUSTTINYCOAL, 200);
 		}
 
 		if (Options.enableColdIron) {

--- a/src/main/java/com/mcmoddev/basemetals/proxy/CommonProxy.java
+++ b/src/main/java/com/mcmoddev/basemetals/proxy/CommonProxy.java
@@ -5,6 +5,7 @@ import com.mcmoddev.basemetals.init.*;
 import com.mcmoddev.basemetals.util.Config;
 import com.mcmoddev.basemetals.util.EventHandler;
 import com.mcmoddev.basemetals.util.Config.Options;
+import com.mcmoddev.lib.fuels.FuelRegistry;
 import com.mcmoddev.lib.integration.IntegrationManager;
 
 import net.minecraftforge.common.MinecraftForge;
@@ -29,6 +30,7 @@ public class CommonProxy {
 		Config.init();
 
 		Materials.init();
+		FuelRegistry.init();
 		cyano.basemetals.init.Materials.init();
 		Fluids.init();
 		ItemGroups.init();
@@ -62,7 +64,7 @@ public class CommonProxy {
 		Recipes.init();
 
 		Achievements.init();
-
+		FuelRegistry.register();
 		IntegrationManager.INSTANCE.runCallbacks("init");
 		MinecraftForge.EVENT_BUS.register(new EventHandler());
 	}

--- a/src/main/java/com/mcmoddev/lib/fuels/FuelRegistry.java
+++ b/src/main/java/com/mcmoddev/lib/fuels/FuelRegistry.java
@@ -1,0 +1,50 @@
+package com.mcmoddev.lib.fuels;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class FuelRegistry {
+	// maps an oreDict to a burnTime
+	private static Map<String,Integer> fuelDicts = new HashMap<>();
+	private static boolean initialized = false;
+	private static Map<Item,Integer> fuels = new HashMap<>();
+	
+	private FuelRegistry() {
+		throw new IllegalAccessError("This class cannot be instantiated!");
+	}
+	
+	public static void init() {
+		if( !initialized ) {
+			initialized = true;
+		}
+		
+	}
+
+	public static void register() {
+		for( Map.Entry<String, Integer> ent : fuelDicts.entrySet() ) {
+			for( ItemStack item : OreDictionary.getOres(ent.getKey())) {
+				if( !fuels.containsKey(item.getItem()) ) { 
+					fuels.put(item.getItem(), ent.getValue());
+				}
+			}
+		}
+		GameRegistry.registerFuelHandler( new MMDFuelHandler() );
+	}
+	
+	public static Map<Item,Integer> getFuels() {
+		return Collections.unmodifiableMap(fuels);
+	}
+	
+	public static void addFuel(String oreDict, int burnTime) {
+		if( !fuelDicts.containsKey(oreDict) ) {
+			fuelDicts.put(oreDict, burnTime);
+		}
+	}
+}
+

--- a/src/main/java/com/mcmoddev/lib/fuels/MMDFuelHandler.java
+++ b/src/main/java/com/mcmoddev/lib/fuels/MMDFuelHandler.java
@@ -1,0 +1,20 @@
+package com.mcmoddev.lib.fuels;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.IFuelHandler;
+
+class MMDFuelHandler implements IFuelHandler {
+	
+	public MMDFuelHandler() {
+	}
+	
+	@Override
+	public int getBurnTime(ItemStack fuel) {
+		if( FuelRegistry.getFuels().containsKey(fuel.getItem()) ) {
+			return FuelRegistry.getFuels().get(fuel.getItem());
+		}
+		
+		return 0;
+	}
+	
+}

--- a/src/main/java/com/mcmoddev/lib/util/Oredicts.java
+++ b/src/main/java/com/mcmoddev/lib/util/Oredicts.java
@@ -232,7 +232,7 @@ public class Oredicts {
 	public static final String INGOTMERCURY = "ingotMercury";
 	public static final String INGOTSTEEL = "ingotSteel";
 
-	public static final String NUGGETCHARCOAL = "nuggetCoal";
+	public static final String NUGGETCHARCOAL = "nuggetCharcoal";
 	public static final String NUGGETCOAL = "nuggetCoal";
 	public static final String NUGGETMERCURY = "nuggetMercury";
 


### PR DESCRIPTION
Implement a new fuel registry system for *metals that takes oreDict names and burn times to generate new fuel entries. This is implemented for Coal/Charcoal nuggets, dusts, small powders and tiny powders