### PR TITLE
Rename the MMDLib base classes of the plugins

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/DenseOres.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/DenseOres.java
@@ -9,7 +9,7 @@ import com.mcmoddev.lib.material.MetalMaterial;
 import com.mcmoddev.lib.util.Oredicts;
 
 @MMDPlugin(addonId = BaseMetals.MODID, pluginId = DenseOres.PLUGIN_MODID)
-public class DenseOres extends com.mcmoddev.lib.integration.plugins.DenseOres implements IIntegration {
+public class DenseOres extends com.mcmoddev.lib.integration.plugins.DenseOresBase implements IIntegration {
 
 	private static boolean initDone = false;
 

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/EnderIO.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/EnderIO.java
@@ -10,7 +10,7 @@ import com.mcmoddev.lib.integration.IIntegration;
  *
  */
 @MMDPlugin(addonId = BaseMetals.MODID, pluginId = EnderIO.PLUGIN_MODID)
-public class EnderIO extends com.mcmoddev.lib.integration.plugins.EnderIO implements IIntegration {
+public class EnderIO extends com.mcmoddev.lib.integration.plugins.EnderIOBase implements IIntegration {
 
 	private static boolean initDone = false;
 

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/IC2.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/IC2.java
@@ -5,7 +5,7 @@ import com.mcmoddev.lib.integration.MMDPlugin;
 import com.mcmoddev.lib.integration.IIntegration;
 
 @MMDPlugin(addonId = BaseMetals.MODID, pluginId = IC2.PLUGIN_MODID)
-public class IC2 extends com.mcmoddev.lib.integration.plugins.IC2 implements IIntegration {
+public class IC2 extends com.mcmoddev.lib.integration.plugins.IC2Base implements IIntegration {
 
 	private static boolean initDone = false;
 

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/Mekanism.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/Mekanism.java
@@ -7,7 +7,7 @@ import com.mcmoddev.lib.integration.MMDPlugin;
 import com.mcmoddev.lib.integration.IIntegration;
 
 @MMDPlugin(addonId = BaseMetals.MODID, pluginId = Mekanism.PLUGIN_MODID)
-public class Mekanism extends com.mcmoddev.lib.integration.plugins.Mekanism implements IIntegration {
+public class Mekanism extends com.mcmoddev.lib.integration.plugins.MekanismBase implements IIntegration {
 
 	private static boolean initDone = false;
 

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/TAIGA.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/TAIGA.java
@@ -20,7 +20,7 @@ import com.sosnitzka.taiga.Blocks;
 import com.sosnitzka.taiga.Items;
 
 @MMDPlugin(addonId = BaseMetals.MODID, pluginId = TAIGA.PLUGIN_MODID)
-public class TAIGA extends com.mcmoddev.lib.integration.plugins.TAIGA implements IIntegration {
+public class TAIGA extends com.mcmoddev.lib.integration.plugins.TAIGABase implements IIntegration {
 
 	private static boolean initDone = false;
 

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/Thaumcraft.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/Thaumcraft.java
@@ -5,7 +5,7 @@ import com.mcmoddev.lib.integration.MMDPlugin;
 import com.mcmoddev.lib.integration.IIntegration;
 
 @MMDPlugin(addonId = BaseMetals.MODID, pluginId = Thaumcraft.PLUGIN_MODID)
-public class Thaumcraft extends com.mcmoddev.lib.integration.plugins.Thaumcraft implements IIntegration {
+public class Thaumcraft extends com.mcmoddev.lib.integration.plugins.ThaumcraftBase implements IIntegration {
 
 	private static boolean initDone = false;
 

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/ThermalExpansion.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/ThermalExpansion.java
@@ -13,7 +13,7 @@ import com.mcmoddev.lib.integration.MMDPlugin;
 import net.minecraft.item.ItemStack;
 
 @MMDPlugin( addonId = BaseMetals.MODID, pluginId = ThermalExpansion.PLUGIN_MODID )
-public class ThermalExpansion extends com.mcmoddev.lib.integration.plugins.ThermalExpansion implements IIntegration {
+public class ThermalExpansion extends com.mcmoddev.lib.integration.plugins.ThermalExpansionBase implements IIntegration {
 
 	private static boolean initDone = false;
 

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
@@ -20,7 +20,7 @@ import com.mcmoddev.lib.integration.plugins.tinkers.TraitLocations;
  *
  */
 @MMDPlugin(addonId = BaseMetals.MODID, pluginId = TinkersConstruct.PLUGIN_MODID, initCallback="doSecondPass")
-public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.TinkersConstruct implements IIntegration {
+public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.TinkersConstructBase implements IIntegration {
 
 	private static boolean initDone = false;
 

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/VeinMiner.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/VeinMiner.java
@@ -11,7 +11,7 @@ import com.mcmoddev.lib.integration.IIntegration;
  *
  */
 @MMDPlugin(addonId = BaseMetals.MODID, pluginId = VeinMiner.PLUGIN_MODID)
-public class VeinMiner extends com.mcmoddev.lib.integration.plugins.VeinMiner implements IIntegration {
+public class VeinMiner extends com.mcmoddev.lib.integration.plugins.VeinMinerBase implements IIntegration {
 
 	private static boolean initDone = false;
 

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/DenseOresBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/DenseOresBase.java
@@ -5,7 +5,7 @@ import com.mcmoddev.lib.integration.IIntegration;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
 
-public class DenseOres implements IIntegration {
+public class DenseOresBase implements IIntegration {
 
 	public static final String PLUGIN_MODID = "denseores";
 

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/EnderIOBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/EnderIOBase.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.event.FMLInterModComms;
  * @author Jasmine Iwanek
  *
  */
-public class EnderIO implements IIntegration {
+public class EnderIOBase implements IIntegration {
 
 	public static final String PLUGIN_MODID = "EnderIO";
 

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/IC2Base.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/IC2Base.java
@@ -9,7 +9,7 @@ import ic2.api.recipe.Recipes;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-public class IC2 implements IIntegration {
+public class IC2Base implements IIntegration {
 
 	public static final String PLUGIN_MODID = "IC2";
 

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/MekanismBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/MekanismBase.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
 
-public class Mekanism implements IIntegration {
+public class MekanismBase implements IIntegration {
 
 	public static final String PLUGIN_MODID = "Mekanism";
 

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/TAIGABase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/TAIGABase.java
@@ -3,7 +3,7 @@ package com.mcmoddev.lib.integration.plugins;
 import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.lib.integration.IIntegration;
 
-public class TAIGA implements IIntegration {
+public class TAIGABase implements IIntegration {
 
 	public static final String PLUGIN_MODID = "taiga";
 

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/ThaumcraftBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/ThaumcraftBase.java
@@ -2,7 +2,7 @@ package com.mcmoddev.lib.integration.plugins;
 
 import com.mcmoddev.lib.integration.IIntegration;
 
-public class Thaumcraft implements IIntegration {
+public class ThaumcraftBase implements IIntegration {
 
 	public static final String PLUGIN_MODID = "thaumcraft";
 

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/ThermalExpansionBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/ThermalExpansionBase.java
@@ -18,7 +18,7 @@ import net.minecraftforge.fml.common.event.FMLInterModComms;
 // of CoFHLib - they were efficient and did the integration in the simplest
 // manner. Why they've been removed, I don't know.
 
-public class ThermalExpansion implements IIntegration {
+public class ThermalExpansionBase implements IIntegration {
 
 	public static final String PLUGIN_MODID = "thermalexpansion";
 	private static boolean initDone = false;
@@ -62,7 +62,7 @@ public class ThermalExpansion implements IIntegration {
 		
 	}
 	
-	public void addFurnace(boolean enabled, String materialName) {
+	public static void addFurnace(boolean enabled, String materialName) {
 		if( enabled ) {
 			MetalMaterial mat = Materials.getMaterialByName(materialName.toLowerCase());
 			/*
@@ -99,7 +99,7 @@ public class ThermalExpansion implements IIntegration {
 		FMLInterModComms.sendMessage("thermalexpansion", "AddCrucibleRecipe", toSend);
 	}
 	
-	public void addCrucible(boolean enabled, String materialName) {
+	public static void addCrucible(boolean enabled, String materialName) {
 		if( enabled ) {
 			MetalMaterial mat = Materials.getMaterialByName(materialName.toLowerCase());
 			/*
@@ -133,14 +133,14 @@ public class ThermalExpansion implements IIntegration {
 		}
 	}
 
-	private void addCrucibleExtra(boolean enabled, Item input, FluidStack output, int energy ) {
+	private static void addCrucibleExtra(boolean enabled, Item input, FluidStack output, int energy ) {
 		if( enabled && input != null && output != null ) {
 			ItemStack inItems = new ItemStack( input, 1 );
 			addCrucibleRecipe( energy, inItems, output );
 		}
 	}
 
-	public void addPlatePress(boolean enabled, String materialName) {
+	public static void addPlatePress(boolean enabled, String materialName) {
 		if( enabled && Options.enablePlate ) {
 			MetalMaterial mat = Materials.getMaterialByName(materialName.toLowerCase());
 			
@@ -152,7 +152,7 @@ public class ThermalExpansion implements IIntegration {
 		}
 	}
 
-	public void addPressStorage(boolean enabled, String materialName) {
+	public static void addPressStorage(boolean enabled, String materialName) {
 		if( enabled ) {
 			MetalMaterial mat = Materials.getMaterialByName(materialName.toLowerCase());
 			

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstructBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstructBase.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fluids.FluidRegistry;
  * @author Daniel Hazelton &lt;dshadowwolf@gmail.com&gt;
  *
  */
-public class TinkersConstruct implements IIntegration {
+public class TinkersConstructBase implements IIntegration {
 	
 	public static final String PLUGIN_MODID = "tconstruct";
 

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/VeinMinerBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/VeinMinerBase.java
@@ -11,7 +11,7 @@ import portablejim.veinminer.api.IMCMessage;
  * @author Jasmine Iwanek
  *
  */
-public class VeinMiner implements IIntegration {
+public class VeinMinerBase implements IIntegration {
 
 	public static final String PLUGIN_MODID = "veinminer";
 


### PR DESCRIPTION
This resolves the SonarLint issue that arises by the derived class having the same name as the base class