### PR TITLE
Track mod of origin

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/init/ItemGroups.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/ItemGroups.java
@@ -19,7 +19,7 @@ public class ItemGroups extends com.mcmoddev.lib.init.ItemGroups {
 
 	private static boolean initDone = false;
 
-	private static final int blocksTabId  = addTab("blocks", true );;
+	private static final int blocksTabId  = addTab("blocks", true );
 	private static final int itemsTabId = addTab("items", true );
 	private static final int toolsTabId = addTab("tools", true );
 	public static final MMDCreativeTab blocksTab = getTab(blocksTabId);

--- a/src/main/java/com/mcmoddev/lib/init/ItemGroups.java
+++ b/src/main/java/com/mcmoddev/lib/init/ItemGroups.java
@@ -3,6 +3,7 @@ package com.mcmoddev.lib.init;
 import net.minecraft.item.*;
 import net.minecraftforge.fml.common.Loader;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +27,7 @@ public class ItemGroups {
 		return delta;
 	};
 
-	private static Map<String, List<MMDCreativeTab>> itemGroupsByModID = new HashMap<>();
+	private static final Map<String, List<MMDCreativeTab>> itemGroupsByModID = new HashMap<>();
 
 	private static boolean initDone = false;
 
@@ -48,10 +49,17 @@ public class ItemGroups {
 
 	protected static int addTab(String name, boolean searchable ) {
 		String modName = Loader.instance().activeModContainer().getModId();
-		MMDCreativeTab tab = new MMDCreativeTab( modName + "." + name, searchable, null );
-		itemGroupsByModID.get(modName).add(tab);
+		String internalTabName = String.format("%s.%s", modName, name);
+		MMDCreativeTab tab = new MMDCreativeTab( internalTabName, searchable, null );
+		if( itemGroupsByModID.containsKey(modName) ) {
+			itemGroupsByModID.get(modName).add(tab);
+		} else {
+			List<MMDCreativeTab> nl = new ArrayList<>();
+			nl.add(tab);
+			itemGroupsByModID.put(modName, nl);
+		}
 		
-		return itemGroupsByModID.get(modName).size();
+		return itemGroupsByModID.get(modName).size() - 1;
 	}
 
 	protected static MMDCreativeTab getTab( int id ) {

--- a/src/main/java/com/mcmoddev/lib/init/Materials.java
+++ b/src/main/java/com/mcmoddev/lib/init/Materials.java
@@ -11,6 +11,7 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.item.Item.ToolMaterial;
 import net.minecraft.item.ItemArmor.ArmorMaterial;
 import net.minecraftforge.common.util.EnumHelper;
+import net.minecraftforge.fml.common.Loader;
 
 /**
  * This class initializes all of the materials in Base Metals. It also contains
@@ -27,7 +28,8 @@ public abstract class Materials {
 	private static Map<String, MMDMaterial> allMaterials = new HashMap<>();
 	private static Map<MMDMaterial, ArmorMaterial> armorMaterialMap = new HashMap<>();
 	private static Map<MMDMaterial, ToolMaterial> toolMaterialMap = new HashMap<>();
-
+	private static Map<String, Set<MMDMaterial>> modSourceMaterialMap = new HashMap<>();
+	
 	protected Materials() {
 		throw new IllegalAccessError("Not a instantiable class");
 	}
@@ -217,6 +219,14 @@ public abstract class Materials {
 		}
 		toolMaterialMap.put(material, toolMaterial);
 
+		if (modSourceMaterialMap.containsKey(Loader.instance().activeModContainer().getModId())) {
+			modSourceMaterialMap.get(Loader.instance().activeModContainer().getModId()).add(material);
+		} else {
+			Set<MMDMaterial> newSet = new TreeSet<>();
+			newSet.add(material);
+			modSourceMaterialMap.put(Loader.instance().activeModContainer().getModId(), newSet);
+			
+		}
 		return material;
 	}
 
@@ -289,5 +299,20 @@ public abstract class Materials {
 	@Deprecated
 	public static MMDMaterial getMetalByName(String materialName) {
 		return allMaterials.get(materialName);
+	}
+	
+	/**
+	 * Gets all materials from a given mod
+	 * 
+	 * @param modId the ModID of the mod
+	 * @return an immutable collection representing all the materials registered by a given mod
+	 *         or the "empty set" if the modId is not recorded.
+	 */
+	public static Collection<MMDMaterial> getMaterialsByMod(String modId) {
+		if (modSourceMaterialMap.containsKey(modId)) {
+			return Collections.unmodifiableSet(modSourceMaterialMap.get(modId));
+		} else {
+			return Collections.emptySet();
+		}
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/init/Materials.java
+++ b/src/main/java/com/mcmoddev/lib/init/Materials.java
@@ -222,7 +222,7 @@ public abstract class Materials {
 		if (modSourceMaterialMap.containsKey(Loader.instance().activeModContainer().getModId())) {
 			modSourceMaterialMap.get(Loader.instance().activeModContainer().getModId()).add(material);
 		} else {
-			Set<MMDMaterial> newSet = new TreeSet<>();
+			Set<MMDMaterial> newSet = new HashSet<>();
 			newSet.add(material);
 			modSourceMaterialMap.put(Loader.instance().activeModContainer().getModId(), newSet);
 			


### PR DESCRIPTION
Change the 'modSourceMaterialMap' from utilizing a TreeSet to utilizing a HashSet - the TreeSet requires that the items being inserted implement Comparable - increasing code complexity with no benefit in this instance.