### PR TITLE
Logic Fixes

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/init/Blocks.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Blocks.java
@@ -1,5 +1,6 @@
 package com.mcmoddev.basemetals.init;
 
+import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.basemetals.data.MaterialNames;
 import com.mcmoddev.basemetals.util.Config.Options;
 import com.mcmoddev.lib.block.BlockHumanDetector;
@@ -226,8 +227,8 @@ public class Blocks extends com.mcmoddev.lib.init.Blocks {
 
 		if (Options.enableStarSteel) {
 			final MMDMaterial material = Materials.getMaterialByName(MaterialNames.STARSTEEL);
-
-			createBlocksFull(material, myTabs);
+			
+			createBlocksFull(material, myTabs);			
 			material.getBlock(Names.BLOCK).setLightLevel(0.5f);
 			material.getBlock(Names.PLATE).setLightLevel(0.5f);
 			material.getBlock(Names.ORE).setLightLevel(0.5f);

--- a/src/main/java/com/mcmoddev/lib/init/Blocks.java
+++ b/src/main/java/com/mcmoddev/lib/init/Blocks.java
@@ -267,8 +267,10 @@ public abstract class Blocks {
 		if ((Options.enableBasics) && (!material.hasBlock(Names.BLOCK))) {
 			final Block block = addBlock(new BlockMMDBlock(material, glow, true), Names.BLOCK, material, tab);
 			Oredicts.registerOre(Oredicts.BLOCK + material.getCapitalizedName(), block);
+			material.addNewBlock(Names.BLOCK, block);
+			return block;
 		}
-		return material.getBlock(Names.BLOCK);
+		return null;
 	}
 
 	/**

--- a/src/main/java/com/mcmoddev/lib/init/Recipes.java
+++ b/src/main/java/com/mcmoddev/lib/init/Recipes.java
@@ -352,7 +352,7 @@ public abstract class Recipes {
 		// NOTE: smelting XP is based on output item, not input item
 		final float oreSmeltXP = material.getOreSmeltXP();
 		
-		if (material.hasItem(Names.INGOT) && (material.getItem(Names.INGOT) instanceof IMMDObject) ) {
+		if (material.hasItem(Names.INGOT)) {
 			if (material.hasOre()) {
 				GameRegistry.addSmelting(new ItemStack(material.getBlock(Names.ORE)), new ItemStack(material.getItem(Names.INGOT), 1), oreSmeltXP);				
 			} else if (material.hasBlend()) {

--- a/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
+++ b/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
@@ -484,7 +484,7 @@ public class MMDMaterial {
 	 * @return the Block registered with the material, null if one of that name was not registered
 	 */
 	public Block getBlock( Names name ) {
-		return getBlock( name.toString() );
+		return this.getBlock( name.toString() );
 	}
 	
 	/**


### PR DESCRIPTION
1) createBlock for creating the actual material block never registered the created block with the MMDMaterial
2) ingot recipe registration was checking for the material being IMMDObject based items - this kept vanilla materials from having any recipes starting or ending with an ingot from being registered