### PR TITLE
Lots of small QOL fixes

### DIFF
--- a/src/main/java/com/mcmoddev/lib/init/Items.java
+++ b/src/main/java/com/mcmoddev/lib/init/Items.java
@@ -358,6 +358,7 @@ public abstract class Items {
 		if (item == null) {
 			return null;
 		}
+		material.addNewItem(name, item);
 		addItem(item, name.toString(), material, tab);
 		return item;
 	}

--- a/src/main/java/com/mcmoddev/lib/init/MMDCreativeTab.java
+++ b/src/main/java/com/mcmoddev/lib/init/MMDCreativeTab.java
@@ -1,10 +1,7 @@
 package com.mcmoddev.lib.init;
 
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 
-import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.basemetals.init.Items;
 
 import net.minecraft.creativetab.CreativeTabs;

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/ThermalExpansionBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/ThermalExpansionBase.java
@@ -77,12 +77,15 @@ public class ThermalExpansionBase implements IIntegration {
 	}
 
 	public static void addFurnace(boolean enabled, String materialName) {
-		if (enabled) {
+		// anything we'd want to add here is likely already pulled in by TE's
+		// import of all vanilla furnace recipes.
+		return;
+/*		if (enabled) {
 			MMDMaterial mat = Materials.getMaterialByName(materialName.toLowerCase());
-			/*
+			
 			 * Ore -> Ingot default, according to TE source, is 2000
 			 * dust -> Ingot default, according to same, is DEFAULT * 14 / 20 - at the 2000RF default, this is 1400
-			 */
+			 
 			final int ENERGY_ORE = 2000;
 			final int ENERGY_DUST = 1400;
 			ItemStack ore;
@@ -107,7 +110,7 @@ public class ThermalExpansionBase implements IIntegration {
 				}
 			}
 		}
-	}
+*/	}
 
 	public static void addCrucible(boolean enabled, String materialName) {
 		if (enabled) {

--- a/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
+++ b/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
@@ -361,7 +361,6 @@ public class MMDMaterial {
 	}
 
 	public String getEnumName() {
-		;
 		return this.enumName;
 	}
 

--- a/src/main/java/com/mcmoddev/lib/recipe/BootsRepairRecipe.java
+++ b/src/main/java/com/mcmoddev/lib/recipe/BootsRepairRecipe.java
@@ -4,88 +4,9 @@ import com.mcmoddev.lib.data.Names;
 import com.mcmoddev.lib.material.MMDMaterial;
 import com.mcmoddev.lib.util.Oredicts;
 
-import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.util.NonNullList;
-import net.minecraft.world.World;
-import net.minecraftforge.oredict.OreDictionary;
-import net.minecraftforge.oredict.ShapelessOreRecipe;
-
-public class BootsRepairRecipe extends ShapelessOreRecipe implements IRecipe {
-
-	private ItemStack baseBoots;
-	private String matName;
+public class BootsRepairRecipe extends RepairRecipeBase {
 
 	public BootsRepairRecipe(MMDMaterial mat) {
-		super(new ItemStack(mat.getItem(Names.BOOTS), 1), new Object[] { mat.getName() + "_boots", Oredicts.PLATE + mat.getCapitalizedName() });
-		baseBoots = new ItemStack(mat.getItem(Names.BOOTS), 1, OreDictionary.WILDCARD_VALUE);
-		matName = mat.getCapitalizedName();
-	}
-
-	@Override
-	public boolean matches(InventoryCrafting inv, World worldIn) {
-		NonNullList<ItemStack> repairMaterials = OreDictionary.getOres(Oredicts.PLATE + matName);
-		boolean bootsMatched = false;
-		boolean repairMatched = false;
-
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack item = inv.getStackInSlot(i);
-			if (!repairMatched) {
-				repairMatched = OreDictionary.containsMatch(false, repairMaterials, item);
-			}
-			if (!bootsMatched) {
-				boolean hasDamage = item.getItemDamage() > 0 ? true : false;
-				bootsMatched = OreDictionary.itemMatches(baseBoots, item, false) ? hasDamage : false;
-			}
-		}
-		return bootsMatched ? repairMatched : false;
-	}
-
-	private ItemStack findBaseItem(InventoryCrafting inv) {
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack a = inv.getStackInSlot(i);
-			if (a != null) {
-				ItemStack comp = new ItemStack(a.getItem(), 1, a.getMetadata());
-				if (OreDictionary.itemMatches(baseBoots, comp, false)) {
-					return a;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public ItemStack getCraftingResult(InventoryCrafting inv) {
-		ItemStack target = findBaseItem(inv);
-		if (target == null) {
-			return new ItemStack(baseBoots.getItem(), 1, 0);
-		} else {
-			ItemStack rv = new ItemStack(target.getItem(), 1, target.getMetadata());
-			EnchantmentHelper.setEnchantments(EnchantmentHelper.getEnchantments(target), rv);
-			rv.setItemDamage(0);
-			return rv;
-		}
-	}
-
-	@Override
-	public int getRecipeSize() {
-		int count = 1;
-		count += OreDictionary.getOres(Oredicts.PLATE + matName).size();
-		return count;
-	}
-
-	@Override
-	public ItemStack getRecipeOutput() {
-		return new ItemStack(baseBoots.getItem(), 1, 0);
-	}
-
-	@Override
-	public NonNullList<Object> getInput() {
-		NonNullList<Object> inputs = NonNullList.create();
-		inputs.add(baseBoots);
-		inputs.addAll(OreDictionary.getOres(Oredicts.PLATE + matName));
-		return inputs;
+		super( mat, Names.BOOTS.toString(), new Object[] { mat.getName() + "_boots", Oredicts.PLATE + mat.getCapitalizedName() });
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/recipe/ChestplateRepairRecipe.java
+++ b/src/main/java/com/mcmoddev/lib/recipe/ChestplateRepairRecipe.java
@@ -4,88 +4,10 @@ import com.mcmoddev.lib.data.Names;
 import com.mcmoddev.lib.material.MMDMaterial;
 import com.mcmoddev.lib.util.Oredicts;
 
-import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.util.NonNullList;
-import net.minecraft.world.World;
-import net.minecraftforge.oredict.OreDictionary;
-import net.minecraftforge.oredict.ShapelessOreRecipe;
-
-public class ChestplateRepairRecipe extends ShapelessOreRecipe implements IRecipe {
-
-	private ItemStack baseChestplate;
-	private String matName;
+public class ChestplateRepairRecipe extends RepairRecipeBase {
 
 	public ChestplateRepairRecipe(MMDMaterial mat) {
-		super(new ItemStack(mat.getItem(Names.CHESTPLATE), 1), new Object[] { mat.getName() + "_chestplate", Oredicts.PLATE + mat.getCapitalizedName() });
-		baseChestplate = new ItemStack(mat.getItem(Names.CHESTPLATE), 1, OreDictionary.WILDCARD_VALUE);
-		matName = mat.getCapitalizedName();
+		super( mat, Names.CHESTPLATE.toString(), new Object[] { mat.getName() + "_chestplate", Oredicts.PLATE + mat.getCapitalizedName() });
 	}
-
-	@Override
-	public boolean matches(InventoryCrafting inv, World worldIn) {
-		NonNullList<ItemStack> repairMaterials = OreDictionary.getOres(Oredicts.PLATE + matName);
-		boolean chestplateMatched = false;
-		boolean repairMatched = false;
-
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack item = inv.getStackInSlot(i);
-			if (!repairMatched) {
-				repairMatched = OreDictionary.containsMatch(false, repairMaterials, item);
-			}
-			if (!chestplateMatched) {
-				boolean hasDamage = item.getItemDamage() > 0 ? true : false;
-				chestplateMatched = OreDictionary.itemMatches(baseChestplate, item, false) ? hasDamage : false;
-			}
-		}
-		return chestplateMatched ? repairMatched : false;
-	}
-
-	private ItemStack findBaseItem(InventoryCrafting inv) {
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack a = inv.getStackInSlot(i);
-			if (a != null) {
-				ItemStack comp = new ItemStack(a.getItem(), 1, a.getMetadata());
-				if (OreDictionary.itemMatches(baseChestplate, comp, false)) {
-					return a;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public ItemStack getCraftingResult(InventoryCrafting inv) {
-		ItemStack target = findBaseItem(inv);
-		if (target == null) {
-			return new ItemStack(baseChestplate.getItem(), 1, 0);
-		} else {
-			ItemStack rv = new ItemStack(target.getItem(), 1, target.getMetadata());
-			EnchantmentHelper.setEnchantments(EnchantmentHelper.getEnchantments(target), rv);
-			rv.setItemDamage(0);
-			return rv;
-		}
-	}
-
-	@Override
-	public int getRecipeSize() {
-		int count = 1;
-		count += OreDictionary.getOres(Oredicts.PLATE + matName).size();
-		return count;
-	}
-
-	@Override
-	public ItemStack getRecipeOutput() {
-		return new ItemStack(baseChestplate.getItem(), 1, 0);
-	}
-
-	@Override
-	public NonNullList<Object> getInput() {
-		NonNullList<Object> inputs = NonNullList.create();
-		inputs.add(baseChestplate);
-		inputs.addAll(OreDictionary.getOres(Oredicts.PLATE + matName));
-		return inputs;
-	}
+	
 }

--- a/src/main/java/com/mcmoddev/lib/recipe/HelmetRepairRecipe.java
+++ b/src/main/java/com/mcmoddev/lib/recipe/HelmetRepairRecipe.java
@@ -4,88 +4,9 @@ import com.mcmoddev.lib.data.Names;
 import com.mcmoddev.lib.material.MMDMaterial;
 import com.mcmoddev.lib.util.Oredicts;
 
-import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.util.NonNullList;
-import net.minecraft.world.World;
-import net.minecraftforge.oredict.OreDictionary;
-import net.minecraftforge.oredict.ShapelessOreRecipe;
-
-public class HelmetRepairRecipe extends ShapelessOreRecipe implements IRecipe {
-
-	private ItemStack baseHelmet;
-	private String matName;
+public class HelmetRepairRecipe extends RepairRecipeBase {
 
 	public HelmetRepairRecipe(MMDMaterial mat) {
-		super(new ItemStack(mat.getItem(Names.HELMET), 1), new Object[] { mat.getName() + "_helmet", Oredicts.PLATE + mat.getCapitalizedName() });
-		baseHelmet = new ItemStack(mat.getItem(Names.HELMET), 1, OreDictionary.WILDCARD_VALUE);
-		matName = mat.getCapitalizedName();
-	}
-
-	@Override
-	public boolean matches(InventoryCrafting inv, World worldIn) {
-		NonNullList<ItemStack> repairMaterials = OreDictionary.getOres(Oredicts.PLATE + matName);
-		boolean helmetMatched = false;
-		boolean repairMatched = false;
-
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack item = inv.getStackInSlot(i);
-			if (!repairMatched) {
-				repairMatched = OreDictionary.containsMatch(false, repairMaterials, item);
-			}
-			if (!helmetMatched) {
-				boolean hasDamage = item.getItemDamage() > 0 ? true : false;
-				helmetMatched = OreDictionary.itemMatches(baseHelmet, item, false) ? hasDamage : false;
-			}
-		}
-		return helmetMatched ? repairMatched : false;
-	}
-
-	private ItemStack findBaseItem(InventoryCrafting inv) {
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack a = inv.getStackInSlot(i);
-			if (a != null) {
-				ItemStack comp = new ItemStack(a.getItem(), 1, a.getMetadata());
-				if (OreDictionary.itemMatches(baseHelmet, comp, false)) {
-					return a;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public ItemStack getCraftingResult(InventoryCrafting inv) {
-		ItemStack target = findBaseItem(inv);
-		if (target == null) {
-			return new ItemStack(baseHelmet.getItem(), 1, 0);
-		} else {
-			ItemStack rv = new ItemStack(target.getItem(), 1, target.getMetadata());
-			EnchantmentHelper.setEnchantments(EnchantmentHelper.getEnchantments(target), rv);
-			rv.setItemDamage(0);
-			return rv;
-		}
-	}
-
-	@Override
-	public int getRecipeSize() {
-		int count = 1;
-		count += OreDictionary.getOres(Oredicts.PLATE + matName).size();
-		return count;
-	}
-
-	@Override
-	public ItemStack getRecipeOutput() {
-		return new ItemStack(baseHelmet.getItem(), 1, 0);
-	}
-
-	@Override
-	public NonNullList<Object> getInput() {
-		NonNullList<Object> inputs = NonNullList.create();
-		inputs.add(baseHelmet);
-		inputs.addAll(OreDictionary.getOres(Oredicts.PLATE + matName));
-		return inputs;
+		super( mat, Names.HELMET.toString(), new Object[] { mat.getName() + "_helmet", Oredicts.PLATE + mat.getCapitalizedName() });
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/recipe/LeggingsRepairRecipe.java
+++ b/src/main/java/com/mcmoddev/lib/recipe/LeggingsRepairRecipe.java
@@ -4,85 +4,10 @@ import com.mcmoddev.lib.data.Names;
 import com.mcmoddev.lib.material.MMDMaterial;
 import com.mcmoddev.lib.util.Oredicts;
 
-import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.util.NonNullList;
-import net.minecraft.world.World;
-import net.minecraftforge.oredict.OreDictionary;
-import net.minecraftforge.oredict.ShapelessOreRecipe;
 
-public class LeggingsRepairRecipe extends ShapelessOreRecipe implements IRecipe {
-
-	private ItemStack baseLeggings;
-	private String matName;
+public class LeggingsRepairRecipe extends RepairRecipeBase {
 
 	public LeggingsRepairRecipe(MMDMaterial mat) {
-		super(new ItemStack(mat.getItem(Names.LEGGINGS), 1), new Object[] { mat.getName() + "_leggings", Oredicts.PLATE + mat.getCapitalizedName() });
-		baseLeggings = new ItemStack(mat.getItem(Names.LEGGINGS), 1, OreDictionary.WILDCARD_VALUE);
-		matName = mat.getCapitalizedName();
-	}
-
-	@Override
-	public boolean matches(InventoryCrafting inv, World worldIn) {
-		NonNullList<ItemStack> repairMaterials = OreDictionary.getOres(Oredicts.PLATE + matName);
-		boolean leggingsMatched = false;
-		boolean repairMatched = false;
-
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack item = inv.getStackInSlot(i);
-			if (!repairMatched) {
-				repairMatched = OreDictionary.containsMatch(false, repairMaterials, item);
-			}
-			if (!leggingsMatched) {
-				boolean hasDamage = item.getItemDamage() > 0 ? true : false;
-				leggingsMatched = OreDictionary.itemMatches(baseLeggings, item, false) ? hasDamage : false;
-			}
-		}
-		return leggingsMatched ? repairMatched : false;
-	}
-
-	private ItemStack findBaseItem(InventoryCrafting inv) {
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack a = inv.getStackInSlot(i);
-			if (a != null) {
-				ItemStack comp = new ItemStack(a.getItem(), 1, a.getMetadata());
-				if (OreDictionary.itemMatches(baseLeggings, comp, false)) {
-					return a;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public ItemStack getCraftingResult(InventoryCrafting inv) {
-		ItemStack target = findBaseItem(inv);
-		if (target == null) {
-			return new ItemStack(baseLeggings.getItem(), 1, 0);
-		} else {
-			target.setItemDamage(0);
-			return target;
-		}
-	}
-
-	@Override
-	public int getRecipeSize() {
-		int count = 1;
-		count += OreDictionary.getOres(Oredicts.PLATE + matName).size();
-		return count;
-	}
-
-	@Override
-	public ItemStack getRecipeOutput() {
-		return new ItemStack(baseLeggings.getItem(), 1, 0);
-	}
-
-	@Override
-	public NonNullList<Object> getInput() {
-		NonNullList<Object> inputs = NonNullList.create();
-		inputs.add(baseLeggings);
-		inputs.addAll(OreDictionary.getOres(Oredicts.PLATE + matName));
-		return inputs;
+		super( mat, Names.LEGGINGS.toString(), new Object[] { mat.getName() + "_leggings", Oredicts.PLATE + mat.getCapitalizedName() });
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/recipe/RepairRecipeBase.java
+++ b/src/main/java/com/mcmoddev/lib/recipe/RepairRecipeBase.java
@@ -1,0 +1,97 @@
+package com.mcmoddev.lib.recipe;
+
+import com.mcmoddev.lib.material.MMDMaterial;
+import com.mcmoddev.lib.util.Oredicts;
+
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
+
+public abstract class RepairRecipeBase extends ShapelessOreRecipe {
+	public final MMDMaterial material;
+	public final ItemStack baseItem;
+	public final String materialName;
+	public final String itemName;
+	public final NonNullList<ItemStack> repairMaterials;
+	
+	public RepairRecipeBase(MMDMaterial material, String itemName, Object...objects) {
+		super( new ItemStack(material.getItem(itemName)), objects);
+		this.material = material;
+		this.baseItem = new ItemStack(material.getItem(itemName));
+		this.materialName = material.getCapitalizedName();
+		this.repairMaterials = OreDictionary.getOres(Oredicts.PLATE + this.materialName);
+		this.itemName = itemName;
+	}
+	
+	@Override
+	public boolean matches(InventoryCrafting inv, World worldIn) {
+		// make sure we have all the materials that can be used for repair, not just what was
+		// available when we were initialized.
+		OreDictionary.getOres(Oredicts.PLATE + this.materialName).stream().filter(item -> !repairMaterials.contains(item) ).forEach(item -> repairMaterials.add(item));
+		
+		boolean matched = false;
+		boolean repairMatched = false;
+
+		for (int i = 0; i < inv.getSizeInventory(); i++) {
+			ItemStack item = inv.getStackInSlot(i);
+			if (!repairMatched) {
+				repairMatched = OreDictionary.containsMatch(false, repairMaterials, item);
+			}
+			if (!matched) {
+				boolean hasDamage = item.getItemDamage() > 0 ? true : false;
+				matched = OreDictionary.itemMatches(this.baseItem, item, false) ? hasDamage : false;
+			}
+		}
+		return matched ? repairMatched : false;
+	}
+
+	private ItemStack findBaseItem(InventoryCrafting inv) {
+		for (int i = 0; i < inv.getSizeInventory(); i++) {
+			ItemStack a = inv.getStackInSlot(i);
+			if (a != null) {
+				ItemStack comp = new ItemStack(a.getItem(), 1, a.getMetadata());
+				if (OreDictionary.itemMatches(this.baseItem, comp, false)) {
+					return a;
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public ItemStack getCraftingResult(InventoryCrafting inv) {
+		ItemStack target = findBaseItem(inv);
+		if (target == null) {
+			return new ItemStack(this.material.getItem(this.itemName));
+		} else {
+			ItemStack rv = new ItemStack(target.getItem(), 1, target.getMetadata());
+			EnchantmentHelper.setEnchantments(EnchantmentHelper.getEnchantments(target), rv);
+			rv.setItemDamage(0);
+			return rv;
+		}
+	}
+
+	@Override
+	public int getRecipeSize() {
+		int count = 1;
+		count += OreDictionary.getOres(Oredicts.PLATE + this.materialName).size();
+		return count;
+	}
+
+	@Override
+	public ItemStack getRecipeOutput() {
+		return new ItemStack( this.material.getItem(this.itemName));
+	}
+
+	@Override
+	public NonNullList<Object> getInput() {
+		NonNullList<Object> inputs = NonNullList.create();
+		inputs.add(this.baseItem);
+		inputs.addAll(OreDictionary.getOres(Oredicts.PLATE + this.materialName));
+		return inputs;
+	}
+}

--- a/src/main/java/com/mcmoddev/lib/recipe/ShieldRepairRecipe.java
+++ b/src/main/java/com/mcmoddev/lib/recipe/ShieldRepairRecipe.java
@@ -4,88 +4,9 @@ import com.mcmoddev.lib.data.Names;
 import com.mcmoddev.lib.material.MMDMaterial;
 import com.mcmoddev.lib.util.Oredicts;
 
-import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.world.World;
-import net.minecraftforge.oredict.OreDictionary;
-import net.minecraftforge.oredict.ShapelessOreRecipe;
-import net.minecraft.util.NonNullList;
-
-public class ShieldRepairRecipe extends ShapelessOreRecipe implements IRecipe {
-
-	private ItemStack baseShield;
-	private String matName;
+public class ShieldRepairRecipe extends RepairRecipeBase {
 
 	public ShieldRepairRecipe(MMDMaterial mat) {
-		super(new ItemStack(mat.getItem(Names.SHIELD), 1), new Object[] { Oredicts.SHIELD + mat.getCapitalizedName(), Oredicts.PLATE + mat.getCapitalizedName() });
-		baseShield = new ItemStack(mat.getItem(Names.SHIELD), 1, OreDictionary.WILDCARD_VALUE);
-		matName = mat.getCapitalizedName();
-	}
-
-	@Override
-	public boolean matches(InventoryCrafting inv, World worldIn) {
-		NonNullList<ItemStack> repairMaterials = OreDictionary.getOres(Oredicts.PLATE + matName);
-		boolean shieldMatched = false;
-		boolean repairMatched = false;
-
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack item = inv.getStackInSlot(i);
-			if (!repairMatched) {
-				repairMatched = OreDictionary.containsMatch(false, repairMaterials, item);
-			}
-			if (!shieldMatched) {
-				boolean hasDamage = item.getItemDamage() > 0 ? true : false;
-				shieldMatched = OreDictionary.itemMatches(baseShield, item, false) ? hasDamage : false;
-			}
-		}
-		return shieldMatched ? repairMatched : false;
-	}
-
-	private ItemStack findBaseItem(InventoryCrafting inv) {
-		for (int i = 0; i < inv.getSizeInventory(); i++) {
-			ItemStack a = inv.getStackInSlot(i);
-			if (a != null) {
-				ItemStack comp = new ItemStack(a.getItem(), 1, a.getMetadata());
-				if (OreDictionary.itemMatches(baseShield, comp, false)) {
-					return a;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public ItemStack getCraftingResult(InventoryCrafting inv) {
-		ItemStack target = findBaseItem(inv);
-		if (target == null) {
-			return new ItemStack(baseShield.getItem(), 1, 0);
-		} else {
-			ItemStack rv = new ItemStack(target.getItem(), 1, target.getMetadata());
-			EnchantmentHelper.setEnchantments(EnchantmentHelper.getEnchantments(target), rv);
-			rv.setItemDamage(0);
-			return rv;
-		}
-	}
-
-	@Override
-	public int getRecipeSize() {
-		int count = 1;
-		count += OreDictionary.getOres(Oredicts.PLATE + matName).size();
-		return count;
-	}
-
-	@Override
-	public ItemStack getRecipeOutput() {
-		return new ItemStack(baseShield.getItem(), 1, 0);
-	}
-
-	@Override
-	public NonNullList<Object> getInput() {
-		NonNullList<Object> inputs = NonNullList.create();
-		inputs.add(baseShield);
-		inputs.addAll(OreDictionary.getOres(Oredicts.PLATE + matName));
-		return inputs;
+		super( mat, Names.SHIELD.toString(), new Object[] { Oredicts.SHIELD + mat.getCapitalizedName(), Oredicts.PLATE + mat.getCapitalizedName() });
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/recipe/ShieldUpgradeRecipe.java
+++ b/src/main/java/com/mcmoddev/lib/recipe/ShieldUpgradeRecipe.java
@@ -17,13 +17,12 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.RecipeRepairItem;
 import net.minecraft.util.NonNullList;
 import net.minecraft.world.World;
 import net.minecraftforge.oredict.OreDictionary;
 
-public class ShieldUpgradeRecipe extends RecipeRepairItem implements IRecipe {
+public class ShieldUpgradeRecipe extends RecipeRepairItem {
 
 	protected String matName;
 


### PR DESCRIPTION
1) Fix issue where armor items are not registered with the material
2) Change armor&shield repair recipes to deriving from a single base class
3) Disable TE plugins redstone furnace integration as TE itself imports everything from the vanilla furnace and we have it all registered there anyway
4) Two small cleanups - one removes a stray, floating semicolon and the other removes some unused imports