### PR TITLE
Fix a mix of API misuse in the CrackHammer

### DIFF
--- a/src/main/java/com/mcmoddev/lib/item/ItemMMDCrackHammer.java
+++ b/src/main/java/com/mcmoddev/lib/item/ItemMMDCrackHammer.java
@@ -132,9 +132,9 @@ public class ItemMMDCrackHammer extends net.minecraft.item.ItemTool implements I
 						double z = target.posZ;
 
 						if (Options.crackHammerFullStack()) {
-							targetItem.shrink(output.getCount());
+							targetItem.setCount(0);
 						} else {
-							targetItem.setCount(targetItem.getCount() - 1);
+							targetItem.shrink(1);
 						}
 						if (targetItem.getCount() <= 0) {
 							w.removeEntity(target);


### PR DESCRIPTION
When cracking full stacks we can just set the output stack to zero directly, as that is always the final value. But when we are cracking by single item, the better method is to use the `shrink()` method with a parameter of 1 (ie: `targetItem.shrink(1);`)

This makes that what is being done