### PR TITLE
first step of adding IoC and decoupling tabcontainer

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/init/Blocks.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Blocks.java
@@ -5,7 +5,9 @@ import com.mcmoddev.basemetals.data.MaterialNames;
 import com.mcmoddev.lib.block.BlockHumanDetector;
 import com.mcmoddev.lib.data.Names;
 import com.mcmoddev.lib.init.Materials;
+import com.mcmoddev.lib.interfaces.ITabProvider;
 import com.mcmoddev.lib.material.MMDMaterial;
+import com.mcmoddev.lib.util.BMeIoC;
 import com.mcmoddev.lib.util.TabContainer;
 
 import net.minecraft.block.Block;
@@ -24,7 +26,7 @@ public class Blocks extends com.mcmoddev.lib.init.Blocks {
 	static Block humanDetector;
 
 	private static boolean initDone = false;
-	private static TabContainer myTabs = ItemGroups.myTabs;
+	private static TabContainer myTabs;
 
 	protected Blocks() {
 		throw new IllegalAccessError("Not a instantiable class");
@@ -37,7 +39,11 @@ public class Blocks extends com.mcmoddev.lib.init.Blocks {
 		if (initDone) {
 			return;
 		}
-
+		
+		// IoC resolutions here
+		BMeIoC IoC = BMeIoC.getInstance();
+		myTabs = IoC.resolve(ITabProvider.class);
+		
 		com.mcmoddev.basemetals.util.Config.init();
 		com.mcmoddev.lib.init.Blocks.init();
 		Materials.init();

--- a/src/main/java/com/mcmoddev/basemetals/init/Items.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Items.java
@@ -13,7 +13,9 @@ import com.mcmoddev.lib.item.ItemMMDPowder;
 import com.mcmoddev.lib.item.ItemMMDSmallPowder;
 import com.mcmoddev.lib.item.ItemMMDBlock;
 import com.mcmoddev.lib.init.Materials;
+import com.mcmoddev.lib.interfaces.ITabProvider;
 import com.mcmoddev.lib.material.MMDMaterial;
+import com.mcmoddev.lib.util.BMeIoC;
 import com.mcmoddev.lib.util.Oredicts;
 import com.mcmoddev.lib.util.TabContainer;
 
@@ -46,6 +48,10 @@ public class Items extends com.mcmoddev.lib.init.Items {
 			return;
 		}
 
+		// IoC resolutions here
+		BMeIoC IoC = BMeIoC.getInstance();
+		myTabs = IoC.resolve(ITabProvider.class);
+		
 		com.mcmoddev.basemetals.util.Config.init();
 		Blocks.init();
 		com.mcmoddev.lib.init.Items.init();

--- a/src/main/java/com/mcmoddev/lib/interfaces/ITabProvider.java
+++ b/src/main/java/com/mcmoddev/lib/interfaces/ITabProvider.java
@@ -1,11 +1,13 @@
 package com.mcmoddev.lib.interfaces;
 
 import com.mcmoddev.lib.init.MMDCreativeTab;
-
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 
 public interface ITabProvider {
 	MMDCreativeTab getTabByName(String tabName);
 	void insertTab(MMDCreativeTab newTab);
 	void addBlockToTab(Block block, String tabName) throws Exception;
+	void addItemToTab(Item item, String tabName) throws Exception;
+	void setIcon(String tabName, String materialName) throws Exception;
 }

--- a/src/main/java/com/mcmoddev/lib/interfaces/ITabProvider.java
+++ b/src/main/java/com/mcmoddev/lib/interfaces/ITabProvider.java
@@ -1,0 +1,11 @@
+package com.mcmoddev.lib.interfaces;
+
+import com.mcmoddev.lib.init.MMDCreativeTab;
+
+import net.minecraft.block.Block;
+
+public interface ITabProvider {
+	MMDCreativeTab getTabByName(String tabName);
+	void insertTab(MMDCreativeTab newTab);
+	void addBlockToTab(Block block, String tabName) throws Exception;
+}

--- a/src/main/java/com/mcmoddev/lib/util/BMeIoC.java
+++ b/src/main/java/com/mcmoddev/lib/util/BMeIoC.java
@@ -1,0 +1,49 @@
+package com.mcmoddev.lib.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.mcmoddev.basemetals.init.ItemGroups;
+import com.mcmoddev.lib.init.MMDCreativeTab;
+import com.mcmoddev.lib.interfaces.ITabProvider;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+
+public class BMeIoC {
+
+	protected ConcurrentHashMap<Class<?>, Object> container = new ConcurrentHashMap<Class<?>, Object>();
+	protected static BMeIoC _instance;
+	
+	protected BMeIoC() {
+	
+	}
+	
+	public <K, V extends K> boolean register(Class<K> key, V value) {
+	    return _instance.container.put(key, value) == null;
+	}
+
+	public <K, V extends K> V resolve(Class<K> keyObject) {
+	    return (V) container.get(keyObject);
+	}
+	
+	public void wireup() {
+		ItemGroups.init();
+		
+		this.register(ITabProvider.class, ItemGroups.myTabs);
+	}
+	
+	public static BMeIoC getInstance() {
+		return getInstance(true);
+	}
+	
+	public static BMeIoC getInstance(Boolean autoWirup) {
+	      if(_instance == null) {
+	         _instance = new BMeIoC();
+	         
+	         if (autoWirup)
+	        	 _instance.wireup();
+	      }
+	      
+	      return _instance;
+	   }
+}

--- a/src/main/java/com/mcmoddev/lib/util/TabContainer.java
+++ b/src/main/java/com/mcmoddev/lib/util/TabContainer.java
@@ -1,9 +1,13 @@
 package com.mcmoddev.lib.util;
 
 import com.mcmoddev.lib.init.MMDCreativeTab;
+import com.mcmoddev.lib.interfaces.ITabProvider;
 
-public final class TabContainer {
+import net.minecraft.block.Block;
 
+public final class TabContainer implements ITabProvider {
+	// @SkyBlade: temporary code until the tabcontainer is replaced
+	
 	public final MMDCreativeTab blocksTab;
 	public final MMDCreativeTab itemsTab;
 	public final MMDCreativeTab toolsTab;
@@ -14,4 +18,33 @@ public final class TabContainer {
 		this.toolsTab = toolsTab;
 	}
 
+	@Override
+	public MMDCreativeTab getTabByName(String tabName) {
+		// rubbish temporary code
+		switch (tabName) {
+		case "blocksTab":
+			return this.blocksTab;			
+		case "itemsTab":
+			return this.itemsTab;
+		case "toolsTab":
+			return this.toolsTab;
+		default:
+			return null;
+		}
+	}
+
+	@Override
+	public void insertTab(MMDCreativeTab newTab) {
+		throw new UnsupportedOperationException(); // old tab provider doesn't add new tabs
+	}
+
+	@Override
+	public void addBlockToTab(Block block, String tabName) throws Exception {
+		MMDCreativeTab tab = this.getTabByName(tabName);
+		
+		if (tab == null) 
+			throw new Exception("Tab not found: " + tabName);
+		
+		block.setCreativeTab(tab);
+	}
 }

--- a/src/main/java/com/mcmoddev/lib/util/TabContainer.java
+++ b/src/main/java/com/mcmoddev/lib/util/TabContainer.java
@@ -1,9 +1,15 @@
 package com.mcmoddev.lib.util;
 
+import com.mcmoddev.basemetals.data.MaterialNames;
+import com.mcmoddev.basemetals.init.Materials;
+import com.mcmoddev.lib.data.Names;
 import com.mcmoddev.lib.init.MMDCreativeTab;
 import com.mcmoddev.lib.interfaces.ITabProvider;
+import com.mcmoddev.lib.material.MMDMaterial;
 
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 
 public final class TabContainer implements ITabProvider {
 	// @SkyBlade: temporary code until the tabcontainer is replaced
@@ -46,5 +52,36 @@ public final class TabContainer implements ITabProvider {
 			throw new Exception("Tab not found: " + tabName);
 		
 		block.setCreativeTab(tab);
+	}
+	
+	@Override
+	public void addItemToTab(Item item, String tabName) throws Exception {
+		MMDCreativeTab tab = this.getTabByName(tabName);
+		
+		if (tab == null) 
+			throw new Exception("Tab not found: " + tabName);
+		
+		item.setCreativeTab(tab);
+	}
+
+	@Override
+	public void setIcon(String tabName, String materialName) throws Exception {
+		MMDCreativeTab tab = this.getTabByName(tabName);
+		
+		if (tab == null) 
+			throw new Exception("Tab not found: " + tabName);
+		
+		Block temp;
+		ItemStack blocksTabIconItem;
+
+		MMDMaterial material = Materials.getMaterialByName(materialName);
+		
+		if ((Materials.hasMaterial(materialName)) && (material.hasBlock(Names.BLOCK)))
+			temp = material.getBlock(Names.BLOCK);
+		else
+			temp = net.minecraft.init.Blocks.IRON_BLOCK;
+		
+		blocksTabIconItem = new ItemStack(Item.getItemFromBlock(temp));
+		blocksTab.setTabIconItem(blocksTabIconItem);
 	}
 }

--- a/src/test/java/com/mcmoddev/basemetals/init/BlocksTests.java
+++ b/src/test/java/com/mcmoddev/basemetals/init/BlocksTests.java
@@ -18,8 +18,7 @@ class BlocksTests {
 
 	@BeforeAll
 	static void setUpBeforeClass() throws Exception {
-		//TODO: Figure out why this doesn't work
-		//Blocks.registerVanilla() ; 
+//		Blocks.registerVanilla() ; 
 	}
 
 	@AfterAll

--- a/src/test/java/com/mcmoddev/lib/util/BMeIocTest.java
+++ b/src/test/java/com/mcmoddev/lib/util/BMeIocTest.java
@@ -1,0 +1,38 @@
+package com.mcmoddev.lib.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.apache.commons.io.IOCase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BMeIocTest {
+
+	static BMeIoC IoC;
+	
+	@BeforeAll
+	static void setUpBeforeClass() throws Exception {
+		IoC = BMeIoC.getInstance();
+	}
+
+	@AfterAll
+	static void tearDownAfterClass() throws Exception {
+	}
+
+	@BeforeEach
+	void setUp() throws Exception {
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+	}
+
+	@Test
+	void testIoCIsInstansiated() {
+		assertNotNull(IoC);
+	}
+
+}

--- a/src/test/java/com/mcmoddev/lib/util/BMeIocTest.java
+++ b/src/test/java/com/mcmoddev/lib/util/BMeIocTest.java
@@ -1,6 +1,7 @@
 package com.mcmoddev.lib.util;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import org.apache.commons.io.IOCase;
 import org.junit.jupiter.api.AfterAll;
@@ -9,13 +10,16 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.mcmoddev.lib.init.MMDCreativeTab;
+import com.mcmoddev.lib.interfaces.ITabProvider;
+
 class BMeIocTest {
 
 	static BMeIoC IoC;
 	
 	@BeforeAll
 	static void setUpBeforeClass() throws Exception {
-		IoC = BMeIoC.getInstance();
+		IoC = BMeIoC.getInstance(false); // cannot yet test autowirup
 	}
 
 	@AfterAll
@@ -35,4 +39,36 @@ class BMeIocTest {
 		assertNotNull(IoC);
 	}
 
+	@Test
+	void testIoCCanRegisterAndResolve() {
+		ITabProvider tabProvider = mock(ITabProvider.class);
+		MMDCreativeTab tab = mock(MMDCreativeTab.class);
+		
+		when(tab.getTabLabel()).thenReturn("blocks tab");
+		when(tabProvider.getTabByName("blocks")).thenReturn(tab);
+		
+		IoC.register(ITabProvider.class, tabProvider);
+		
+		ITabProvider tabProviderResolved = IoC.resolve(ITabProvider.class);
+		MMDCreativeTab tabResolved = tabProviderResolved.getTabByName("blocks");
+		
+		assertNotNull(tabResolved);
+		assertEquals(tabResolved.getTabLabel(), "blocks tab");
+	}
+	
+	@Test
+	void testIoCCanRegisterAndNotResolve() {
+		ITabProvider tabProvider = mock(ITabProvider.class);
+		MMDCreativeTab tab = mock(MMDCreativeTab.class);
+		
+		when(tab.getTabLabel()).thenReturn("blocks tab");
+		when(tabProvider.getTabByName("blocks")).thenReturn(tab);
+		
+		IoC.register(ITabProvider.class, tabProvider);
+		
+		ITabProvider tabProviderResolved = IoC.resolve(ITabProvider.class);
+		MMDCreativeTab tabResolved = tabProviderResolved.getTabByName("blocks2");
+		
+		assertNull(tabResolved);
+	}
 }


### PR DESCRIPTION
The purpose of this PR is to introduce the first iteration of the IoC container (the be extended later), and to begin decoupling the tabcontainer by wrapping it in an interface.

Next steps will be to fully decouple to tabcontainer from its consuming classes, and then to replace the tabcontainer with a new tabprovider