### PR TITLE
make horse armor code work with forge built in when present

### DIFF
--- a/src/main/java/com/mcmoddev/lib/asm/ASMHooks.java
+++ b/src/main/java/com/mcmoddev/lib/asm/ASMHooks.java
@@ -32,7 +32,7 @@ public class ASMHooks {
 	public static String getTextureName(HorseArmorType type, EntityHorse entity) {
 		final ItemStack stack = entity.getDataManager().get(ASMHooks.ARMOR_STACK);
 		if (!stack.isEmpty() && stack.getItem() instanceof IHorseArmor)
-			return ((IHorseArmor) stack.getItem()).getArmorTexture(entity, stack);
+			return ((IHorseArmor) stack.getItem()).getHorseArmorTexture(entity, stack);
 		return type.getTextureName();
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/asm/ASMPlugin.java
+++ b/src/main/java/com/mcmoddev/lib/asm/ASMPlugin.java
@@ -8,25 +8,33 @@ import javax.annotation.Nullable;
 
 import com.mcmoddev.lib.util.Platform;
 
+import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.MCVersion;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.Name;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.SortingIndex;
 
 @Name("BaseMetals")
-@MCVersion("1.12.2")
 @SortingIndex(1001)
 public class ASMPlugin implements IFMLLoadingPlugin {
 
 	static List<ITransformer> transformerList = new ArrayList<>();
 
+	//HorseArmor patches present in 1.12.2-14.23.1.2592+
+	private static final boolean NEEDS_HORSE_ARMOR_PATCH = ForgeVersion.getMajorVersion() < 14 || ForgeVersion.getMinorVersion() < 23 || ForgeVersion.getRevisionVersion() < 1 || ForgeVersion.getBuildVersion() < 2592;
+
 	public ASMPlugin() {
-		transformerList.add(new EntityHorseTransformer());
-		transformerList.add(new HorseArmorTypeTransformer());
+		if (NEEDS_HORSE_ARMOR_PATCH) {
+			transformerList.add(new EntityHorseTransformer());
+			transformerList.add(new HorseArmorTypeTransformer());
+		}
+		//if you add more here, you must remove the check below in getASMTransformerClass()!
 	}
 
 	@Override
 	public String[] getASMTransformerClass() {
+		if (!NEEDS_HORSE_ARMOR_PATCH)
+			return null;
 		return new String[] { ASMTransformer.class.getName() };
 	}
 

--- a/src/main/java/com/mcmoddev/lib/asm/HorseArmorTypeTransformer.java
+++ b/src/main/java/com/mcmoddev/lib/asm/HorseArmorTypeTransformer.java
@@ -39,8 +39,9 @@ class HorseArmorTypeTransformer implements ITransformer {
 						mv.visitJumpInsn(IFEQ, label1);
 						mv.visitVarInsn(ALOAD, 0);
 						mv.visitTypeInsn(CHECKCAST, HORSE_INTERFACE);
-						mv.visitMethodInsn(INVOKEINTERFACE, HORSE_INTERFACE, "getArmorType",
-								"()Lnet/minecraft/entity/passive/HorseArmorType;", true);
+						mv.visitInsn(Opcodes.ACONST_NULL);
+						mv.visitMethodInsn(INVOKEINTERFACE, HORSE_INTERFACE, "getHorseArmorType",
+								"(Lnet/minecraft/item/ItemStack;)Lnet/minecraft/entity/passive/HorseArmorType;", true);
 						mv.visitInsn(ARETURN);
 						mv.visitLabel(label1);
 						mv.visitFrame(F_SAME, 0, null, 0, null);

--- a/src/main/java/com/mcmoddev/lib/common/item/IHorseArmor.java
+++ b/src/main/java/com/mcmoddev/lib/common/item/IHorseArmor.java
@@ -1,9 +1,12 @@
 package com.mcmoddev.lib.common.item;
 
-import net.minecraft.entity.passive.EntityHorse;
+import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.passive.HorseArmorType;
 import net.minecraft.item.ItemStack;
 
+/**
+ * This interface matches the forge Item additions, please don't change.
+ */
 public interface IHorseArmor {
 
 	/**
@@ -11,8 +14,9 @@ public interface IHorseArmor {
 	 *
 	 * @return The {@link HorseArmorType} that this horse armor will have the
 	 *         values of.
+	 * @param stack {@link ItemStack} being checked (forge compat)
 	 */
-	HorseArmorType getArmorType();
+	HorseArmorType getHorseArmorType(ItemStack stack);
 
 	/**
 	 * Returns the location of the custom horse armor texture, similar to how
@@ -25,5 +29,5 @@ public interface IHorseArmor {
 	 *
 	 * @return The location of the custom horse armor
 	 */
-	String getArmorTexture(EntityHorse horse, ItemStack stack);
+	String getHorseArmorTexture(EntityLiving horse, ItemStack stack);
 }

--- a/src/main/java/com/mcmoddev/lib/item/ItemMMDHorseArmor.java
+++ b/src/main/java/com/mcmoddev/lib/item/ItemMMDHorseArmor.java
@@ -1,12 +1,15 @@
 package com.mcmoddev.lib.item;
 
+import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.lib.common.item.IHorseArmor;
 import com.mcmoddev.lib.material.MMDMaterial;
-import com.mcmoddev.lib.util.HorseArmorUtils;
 
-import net.minecraft.entity.passive.EntityHorse;
+import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.passive.HorseArmorType;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.util.EnumHelper;
+
+import java.util.Locale;
 
 /**
  *
@@ -15,19 +18,32 @@ import net.minecraft.item.ItemStack;
  */
 public class ItemMMDHorseArmor extends GenericMMDItem implements IHorseArmor {
 
+	private final HorseArmorType myArmorType;
+
 	public ItemMMDHorseArmor(final MMDMaterial material) {
 		super(material);
 		this.setMaxStackSize(1);
+		this.myArmorType = addArmorType(material.getName(), material.getHorseArmorProtection());
 	}
 
 	@Override
-	public HorseArmorType getArmorType() {
-		// return HorseArmorType.DIAMOND;
-		return HorseArmorUtils.getArmorType(1024, "test", "tes");
+	public HorseArmorType getHorseArmorType(ItemStack stack) {
+		if (stack != null && stack.getItem() != this){//NB stack CAN be null, when our ASM does it
+			return HorseArmorType.NONE;
+		}
+		return myArmorType;
 	}
 
 	@Override
-	public String getArmorTexture(final EntityHorse entity, final ItemStack stack) {
-		return stack.getItem().getRegistryName().getResourceDomain() + ":textures/entity/horse/armor/horse_armor_" + getMMDMaterial().getName() + ".png";
+	public String getHorseArmorTexture(final EntityLiving entity, final ItemStack stack) {
+		return stack.getItem() == this ? getArmorTexture() : "";
+	}
+
+	private String getArmorTexture(){
+		return getRegistryName().getResourceDomain() + ":textures/entity/horse/armor/horse_armor_" + getMMDMaterial().getName() + ".png";
+	}
+
+	private static HorseArmorType addArmorType(String materialName, int protectionLevel){
+		return EnumHelper.addEnum(HorseArmorType.class, "BASEMETALS_"+materialName.toUpperCase(Locale.ROOT), new Class[] { int.class, String.class, String.class }, protectionLevel, materialName, BaseMetals.MODID+"_"+materialName);
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
+++ b/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
@@ -342,6 +342,15 @@ public class MMDMaterial extends IForgeRegistryEntry.Impl<MMDMaterial> {
 	}
 
 	/**
+	 * Gets the Horse armor protection value, where Diamond is 11 in vanilla.
+	 *
+	 * @return the {@link net.minecraft.entity.passive.HorseArmorType#protection} value
+	 */
+	public int getHorseArmorProtection(){
+		return (int) (this.stats.get(MaterialStats.HARDNESS) / 10.0 * 11.0);
+	}
+
+	/**
 	 * Gets the protection value for helmets, chestplates, leg armor, and boots
 	 * made from this material
 	 * 


### PR DESCRIPTION
Makes horse armor interface mimic forge's `Item` additions, so the transformer can no-op when the requisite forge version is used.

Currently only copper armor has a texture, others will give a texture-less horse.