### PR TITLE
tooling updates

### DIFF
--- a/tools/os3-format-upgrade/convert-to-2.0.js
+++ b/tools/os3-format-upgrade/convert-to-2.0.js
@@ -2,8 +2,10 @@ const fs = require("fs"),
       util = require("util"),
       console = require("console");
 
+const input_file = process.argv[2];
+const output_file = process.argv[3];
 
-const original_data = JSON.parse( fs.readFileSync( "basemetals.json" ) );
+const original_data = JSON.parse( fs.readFileSync( input_file ) );
 
 const new_data = { "version": "2.0", "spawns": {} };
 
@@ -29,4 +31,4 @@ for( var i = 0; i < original_data.dimensions.length; i++ ) {
 
 var out =  JSON.stringify( new_data, null, "\t" );
 
-fs.writeFileSync( "basemetals-new.json", out );
+fs.writeFileSync( output_file, out );

--- a/tools/os3-format-upgrade/os1-to-os3.js
+++ b/tools/os3-format-upgrade/os1-to-os3.js
@@ -1,0 +1,49 @@
+const fs = require("fs"),
+      util = require("util"),
+      console = require("console");
+
+const input_file = process.argv[2];
+const output_file = process.argv[3];
+
+const original_data = JSON.parse( fs.readFileSync( input_file ) );
+
+const new_data = { "version": "2.0", "spawns": {} };
+
+for( var i = 0; i < original_data.dimensions.length; i++ ) {
+    var this_dim = original_data.dimensions[i];
+    let dimBlock = this_dim.dimension=="+"?[]:[this_dim.dimension];
+    for( var j = 0; j < this_dim.ores.length; j++ ) {
+	var this_spawn = this_dim.ores[j];
+	var parameters = {};
+	parameters.size = this_spawn.size;
+	parameters.variation = this_spawn.variation;
+	parameters.frequency = this_spawn.frequency;
+	parameters.minHeight = this_spawn.minHeight;
+	parameters.maxHeight = this_spawn.maxHeight;
+	let biomeBlock = { "excludes": [] };
+	if( this_spawn.hasOwnProperty("biomes") ) {
+	    biomeBlock = this_spawn.biomes.length>0?{ "includes": this_dim.biomes }:{ "excludes": [] };
+	}
+	var ns = {
+		"retrogen": false,
+		"enabled": true,
+		"feature": "default",
+		"replaces": "default",
+		"dimensions": dimBlock ,
+		"biomes": biomeBlock,
+		"parameters": parameters };
+	var block = { "name": this_spawn.blockID, "chance": 100 };
+	if( this_spawn.hasOwnProperty('metaData') ) {
+	    block.metaData = this_spawn.metaData;
+	} else if( this_spawn.hasOwnProperty('state') ) {
+	    block.state = this_spawn.state;
+	}
+	var name = block.name.split(":")[1];
+	ns.blocks = [ block ];
+	new_data.spawns[name] = ns;
+    }
+}
+
+var out =  JSON.stringify( new_data, null, "\t" );
+
+fs.writeFileSync( output_file, out );


### PR DESCRIPTION
1) Fix the OS3v1.x to 2.0 converter to take a pair of command-line parameters - the first being the input file, the second being the filename to output to
2) Add a tool for converting OS1 configs to OS3v2.0 configs - this has the same command-line parameters as the original conversion tool