### PR TITLE
small fixes across the board for issues run into while fixing up EndMetals and NetherMetals

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/IC2.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/IC2.java
@@ -67,15 +67,11 @@ public class IC2 extends com.mcmoddev.lib.integration.plugins.IC2Base implements
 	}
 	
 	public void doHammerRecipes() {
-		BaseMetals.logger.fatal("IC2 Hammer Recipes, Go!");
 		final List<String> materials = Arrays.asList(MaterialNames.ADAMANTINE, MaterialNames.ANTIMONY,
 				MaterialNames.BISMUTH, MaterialNames.COLDIRON, MaterialNames.PLATINUM, MaterialNames.NICKEL,
 				MaterialNames.STARSTEEL, MaterialNames.ZINC);
 		materials.stream().filter(Materials::hasMaterial)
 		.filter(materialName -> !Materials.getMaterialByName(materialName).isEmpty())
-		.forEach(materialName -> {
-			BaseMetals.logger.fatal("Adding Forge Hammer recipes for %s", materialName);
-			addForgeHammerRecipe(materialName);
-		});
+		.forEach(this::addForgeHammerRecipe);
 	}
 }

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
@@ -18,8 +18,6 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import slimeknights.tconstruct.library.TinkerRegistry;
-import slimeknights.tconstruct.library.modifiers.IModifier;
 
 /**
  *
@@ -80,10 +78,6 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		if(postInit) return;
 		postInit = true;
 		postInitSetup(BaseMetals.MODID);
-		for( IModifier mod : TinkerRegistry.getAllModifiers() ) {
-			BaseMetals.logger.fatal("Modifier (?) %s (%s) has item: %s", mod.getIdentifier(),
-					mod.getClass(), mod.hasItemsToApplyWith());
-		}
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/MekanismBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/MekanismBase.java
@@ -78,7 +78,7 @@ public class MekanismBase implements IIntegration {
 
 		addCrusherRecipe(clump, powderDirty);
 		addCrusherRecipe(ingot, powder);
-		addCrusherRecipe(ore, material.getItemStack(Names.POWDER, 2));
+
 		addEnrichmentChamberRecipe(ore, new ItemStack(powder.getItem(), 2));
 		addEnrichmentChamberRecipe(powderDirty, powder);
 		addPurificationChamberRecipe(ore, new ItemStack(clump.getItem(), 3));

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstructBase.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstructBase.java
@@ -2,6 +2,7 @@ package com.mcmoddev.lib.integration.plugins;
 
 import javax.annotation.Nonnull;
 
+import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.basemetals.init.Materials;
 import com.mcmoddev.lib.integration.IIntegration;
 import com.mcmoddev.lib.integration.plugins.tinkers.ModifierRegistry;

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TinkersConstructRegistry.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TinkersConstructRegistry.java
@@ -194,7 +194,7 @@ public class TinkersConstructRegistry {
 		
 		if( myMelts.isEmpty())
 			return;
-		
+
 		for( final Entry<Item, FluidStack> ent : myMelts.entrySet() ) {
 			Item item = ent.getKey();
 			FluidStack fluidStack = ent.getValue();

--- a/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
+++ b/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.lib.data.MaterialStats;
 import com.mcmoddev.lib.data.Names;
@@ -628,6 +629,10 @@ public class MMDMaterial extends IForgeRegistryEntry.Impl<MMDMaterial> {
 		return new ItemStack(getBlock(name), amount);
 	}
 
+	public Map<String,Block> getBlockRegistry() {
+		return ImmutableMap.copyOf(this.blocks);
+	}
+	
 	/**
 	 * Get all the blocks that are made from this material
 	 * @return ImmutableList&lt;Block&gt; - the blocks
@@ -760,5 +765,9 @@ public class MMDMaterial extends IForgeRegistryEntry.Impl<MMDMaterial> {
 
 	public boolean isEmpty() {
 		return ("empty".equals(this.getName()));
+	}
+
+	public Map<String, Item> getItemRegistry() {
+		return ImmutableMap.copyOf(this.items);
 	}
 }


### PR DESCRIPTION
1) Remove lots of unnecessary debugging
2) Some code cleanup and streamlining
3) General mod plugin cleanups
4) Debugging function for dumping the entire materials registry to disk
5) Helpers for #4 added to MMDMaterial
6) Correct mistake made due to lack of sleep in Mek interaction plugin