### PR TITLE
add Materials.DEFAULT

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/init/Blocks.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Blocks.java
@@ -3,6 +3,7 @@ package com.mcmoddev.basemetals.init;
 import java.util.Arrays;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.basemetals.data.MaterialNames;
 import com.mcmoddev.lib.block.BlockHumanDetector;
@@ -14,6 +15,7 @@ import com.mcmoddev.lib.material.MMDMaterial;
 import net.minecraft.block.Block;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.registries.IForgeRegistry;
 
 /**
  * This class initializes all blocks in Base Metals.
@@ -22,8 +24,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
  *
  */
 public final class Blocks extends com.mcmoddev.lib.init.Blocks {
-
-	public static Block humanDetector;
 
 	private Blocks() {
 		throw new IllegalAccessError(SharedStrings.NOT_INSTANTIABLE);
@@ -64,7 +64,7 @@ public final class Blocks extends com.mcmoddev.lib.init.Blocks {
 		createMercury();
 		createAnvils();
 
-		humanDetector = addBlock(new BlockHumanDetector(), "human_detector", ItemGroups.getTab(SharedStrings.TAB_BLOCKS));
+		addBlock(new BlockHumanDetector(), "human_detector", ItemGroups.getTab(SharedStrings.TAB_BLOCKS));
 	}
 
 	private static void createAnvils() {
@@ -226,16 +226,15 @@ public final class Blocks extends com.mcmoddev.lib.init.Blocks {
 	 */
 	@SubscribeEvent
 	public static void registerBlocks(final RegistryEvent.Register<Block> event) {
-		for (MMDMaterial mat : Materials.getMaterialsByMod(BaseMetals.MODID)) {
-			for (Block block : mat.getBlocks()) {
-				if (block.getRegistryName().getResourceDomain().equals(BaseMetals.MODID)) {
-					event.getRegistry().register(block);
-				}
-			}
-		}
+		Materials.getMaterialsByMod(BaseMetals.MODID).stream()
+		.forEach(mat -> regBlocks(event.getRegistry(), mat.getBlocks()));
 
-		if (humanDetector != null) {
-			event.getRegistry().register(humanDetector);
-		}
+		regBlocks(event.getRegistry(), Materials.DEFAULT.getBlocks());
+	}
+
+	private static void regBlocks(IForgeRegistry<Block> registry, ImmutableList<Block> blocks) {
+		blocks.stream()
+		.filter(block -> block.getRegistryName().getResourceDomain().toString().equals(BaseMetals.MODID))
+		.forEach(registry::register);
 	}
 }

--- a/src/main/java/com/mcmoddev/basemetals/init/Items.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Items.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import com.google.common.collect.ImmutableList;
 import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.basemetals.data.MaterialNames;
 import com.mcmoddev.lib.data.Names;
@@ -22,6 +23,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.registries.IForgeRegistry;
 
 /**
  * This class initializes all items in Base Metals.
@@ -373,24 +375,18 @@ public final class Items extends com.mcmoddev.lib.init.Items {
 	 */
 	@SubscribeEvent
 	public static void registerItems(final RegistryEvent.Register<Item> event) {
-		for (MMDMaterial mat : Materials.getMaterialsByMod(BaseMetals.MODID)) {
-			for (Item item : mat.getItems()) {
-				if (item.getRegistryName().getResourceDomain().equals(BaseMetals.MODID)) {
-					event.getRegistry().register(item);
-				}
-			}
-		}
+		Materials.getMaterialsByMod(BaseMetals.MODID).stream()
+		.forEach( mat -> regItems(event.getRegistry(), mat.getItems()));
 
-		if (Blocks.humanDetector != null) {
-			final ItemBlock itemBlock = new ItemBlock(Blocks.humanDetector);
-
-			itemBlock.setRegistryName("human_detector");
-			itemBlock
-					.setUnlocalizedName(Blocks.humanDetector.getRegistryName().getResourceDomain() + ".human_detector");
-			event.getRegistry().register(itemBlock);
-		}
-
+		regItems(event.getRegistry(), Materials.DEFAULT.getItems());
+		
 		Oredicts.registerItemOreDictionaryEntries();
 		Oredicts.registerBlockOreDictionaryEntries();
+	}
+
+	private static void regItems(IForgeRegistry<Item> registry, ImmutableList<Item> items) {
+		items.stream()
+		.filter( item -> item.getRegistryName().getResourceDomain().toString().equals(BaseMetals.MODID))
+		.forEach(registry::register);
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/init/Blocks.java
+++ b/src/main/java/com/mcmoddev/lib/init/Blocks.java
@@ -183,12 +183,12 @@ public abstract class Blocks {
 
 	@Nullable
 	protected static Block addBlock(@Nonnull final Block block, @Nonnull final Names name, final CreativeTabs tab) {
-		return addBlock(block, name.toString(), Materials.EMPTY, tab);
+		return addBlock(block, name.toString(), Materials.DEFAULT, tab);
 	}
 
 	@Nullable
 	protected static Block addBlock(@Nonnull final Block block, @Nonnull final String name, final CreativeTabs tab) {
-		return addBlock(block, name, Materials.EMPTY, tab);
+		return addBlock(block, name, Materials.DEFAULT, tab);
 	}
 
 	/**
@@ -257,7 +257,7 @@ public abstract class Blocks {
 		} else if ((name.startsWith("nether")) || (name.startsWith("end"))) {
 			String neededBit = name.substring(0, name.length() - 3);
 			return String.format("%s_%s_%s", neededBit, material.getName(), Names.ORE);
-		} else if (!material.isEmpty()) {
+		} else if ((!material.isEmpty()) && (!material.isDefault())) {
 			return String.format("%s_%s", material.getName(), name);
 		} else {
 			return name;

--- a/src/main/java/com/mcmoddev/lib/init/Items.java
+++ b/src/main/java/com/mcmoddev/lib/init/Items.java
@@ -319,12 +319,12 @@ public abstract class Items {
 
 	@Nullable
 	protected static Item addItem(@Nonnull final Item item, @Nonnull final Names name, final CreativeTabs tab) {
-		return addItem(item, name.toString(), Materials.EMPTY, tab);
+		return addItem(item, name.toString(), Materials.DEFAULT, tab);
 	}
 
 	@Nullable
 	protected static Item addItem(@Nonnull final Item item, @Nonnull final String name, final CreativeTabs tab) {
-		return addItem(item, name, Materials.EMPTY, tab);
+		return addItem(item, name, Materials.DEFAULT, tab);
 	}
 
 	/**
@@ -343,7 +343,7 @@ public abstract class Items {
 	protected static Item addItem(@Nonnull final Item item, @Nonnull final String name, final MMDMaterial material,
 			final CreativeTabs tab) {
 		String fullName;
-		if (!material.isEmpty()) {
+		if ((!material.isEmpty()) && (!material.isDefault())) {
 			if (material.hasItem(name)) {
 				return material.getItem(name);
 			}

--- a/src/main/java/com/mcmoddev/lib/init/Materials.java
+++ b/src/main/java/com/mcmoddev/lib/init/Materials.java
@@ -43,7 +43,8 @@ public class Materials {
 	private static final Map<MMDMaterial, ToolMaterial> toolMaterialMap = new HashMap<>();
 
 	public static final MMDMaterial EMPTY = createOrelessMaterial("empty", MaterialType.METAL, 0, 0, 0, 0);
-
+	public static final MMDMaterial DEFAULT = createOrelessMaterial("default", MaterialType.METAL, 0, 0, 0, 0);
+	
 	protected Materials() {
 		// this only exists to allow for the "instance" variable
 	}

--- a/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
+++ b/src/main/java/com/mcmoddev/lib/material/MMDMaterial.java
@@ -810,6 +810,10 @@ public class MMDMaterial extends IForgeRegistryEntry.Impl<MMDMaterial> {
 		return ("empty".equals(this.getName()));
 	}
 
+	public boolean isDefault() {
+		return ("default".equalsIgnoreCase(this.getName()));
+	}
+	
 	public Map<String, Item> getItemRegistry() {
 		return ImmutableMap.copyOf(this.items);
 	}


### PR DESCRIPTION
1) add MMDMaterial "DEFAULT" to com.mcmoddev.lib.init.Materials to use as a holding unit for any block or item created with no material
2) add MMDMaterial::isDefault as a helper for determining if the material being referenced is Materials.DEFAULT
3) change com.mcmoddev.lib.init.Blocks to use Materials.DEFAULT instead of Materials.EMPTY in those functions that allow for adding or creating a block without an underlying material
4) alter helper functions in the same so Materials.DEFAULT does not prepend presented registry names with "default_"
5) change com.mcmoddev.lib.init.Items in the same manner as 'Blocks' was changed
6) same as 4, but for 'Items'
7) alter BaseMetals block registration callback to handle registering for Materials.DEFAULT
8) alter BaseMetals block registration callback to not be idiotically written
9) alter BaseMetals item registration callback to handle Materials.DEFAULT
10) again, change the item registration callback to not look like it came from the proverbial shakespearian monkeys