### PR TITLE
fix the bug with the crackhammer being returned to the user with 0 durability in some situations

### DIFF
--- a/src/main/java/com/mcmoddev/lib/item/ItemMMDCrackHammer.java
+++ b/src/main/java/com/mcmoddev/lib/item/ItemMMDCrackHammer.java
@@ -120,6 +120,7 @@ public class ItemMMDCrackHammer extends net.minecraft.item.ItemTool implements I
 			this.maybeDoCrack(recipe, targetItem, item, entities.get(0), player, w);
 			w.playSound(player, coord, SoundEvents.BLOCK_GRAVEL_BREAK, SoundCategory.BLOCKS, 0.5F,
 					0.5F + (itemRand.nextFloat() * 0.3F));
+
 			return EnumActionResult.SUCCESS;
 		}
 
@@ -142,6 +143,10 @@ public class ItemMMDCrackHammer extends net.minecraft.item.ItemTool implements I
 			this.spawnResults(output, x, y, z, crackedCount, w);
 
 			item.damageItem(crackedCount, player);
+			// if the items damage is maxed, lets increase it anyway and put it out of its misery
+			if(item.getMaxDamage() == item.getItemDamage()) {
+				item.damageItem(1, player);
+			}
 		}
 	}
 


### PR DESCRIPTION
It seems that tools break when they pass "max durability" and not at "max durability" - this change makes it so that when a crackhammer has been used to the max of its durability, we automatically add one more damage to break it so the user isn't left with a tool that has 0 durability.