### PR TITLE
Fix sickles/scythes and some minor cleanups

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/BaseMetals.java
+++ b/src/main/java/com/mcmoddev/basemetals/BaseMetals.java
@@ -3,14 +3,10 @@ package com.mcmoddev.basemetals;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.mcmoddev.basemetals.data.MaterialNames;
-import com.mcmoddev.basemetals.init.Materials;
 import com.mcmoddev.basemetals.proxy.CommonProxy;
 import com.mcmoddev.basemetals.util.Config;
-import com.mcmoddev.lib.data.Names;
 import com.mcmoddev.lib.data.SharedStrings;
 import com.mcmoddev.lib.integration.IntegrationManager;
-import com.mcmoddev.lib.util.CheeseMath;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;

--- a/src/main/java/com/mcmoddev/lib/item/GenericMMDItem.java
+++ b/src/main/java/com/mcmoddev/lib/item/GenericMMDItem.java
@@ -2,10 +2,15 @@ package com.mcmoddev.lib.item;
 
 import javax.annotation.Nonnull;
 
+import com.google.common.collect.Multimap;
+import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.lib.material.IMMDObject;
 import com.mcmoddev.lib.material.MMDMaterial;
 
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Item;
 
 /**
  * version of Item that stores a material.
@@ -13,7 +18,7 @@ import net.minecraft.item.ItemStack;
  * @author DrCyano
  *
  */
-public class GenericMMDItem extends net.minecraft.item.Item implements IMMDObject {
+public class GenericMMDItem extends Item implements IMMDObject {
 
 	private int burnTime = 0;
 	private final MMDMaterial material;
@@ -44,7 +49,7 @@ public class GenericMMDItem extends net.minecraft.item.Item implements IMMDObjec
 			return itemStack.getItem().getItemBurnTime(itemStack);
 		}
 	}
-	
+
 /*	@Override
 	public float getSmeltingExperience(ItemStack itemStack) {
 		// clamp to the valid range

--- a/src/main/java/com/mcmoddev/lib/item/ItemMMDSickle.java
+++ b/src/main/java/com/mcmoddev/lib/item/ItemMMDSickle.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.mcmoddev.basemetals.BaseMetals;
+import com.mcmoddev.lib.init.Materials;
 import com.mcmoddev.lib.material.IMMDObject;
 import com.mcmoddev.lib.material.MMDMaterial;
 
@@ -34,8 +35,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraft.item.ItemTool;
 
-public class ItemMMDSickle extends GenericMMDItem implements IMMDObject {
+public class ItemMMDSickle extends ItemTool implements IMMDObject {
 
 	public static final ImmutableSet<Material> vanilla_materials = ImmutableSet.of(Material.WEB,
 			Material.LEAVES, Material.PLANTS, Material.VINE, Material.GOURD, Material.CACTUS);
@@ -51,7 +53,7 @@ public class ItemMMDSickle extends GenericMMDItem implements IMMDObject {
 	 * @param material
 	 */
 	public ItemMMDSickle(final MMDMaterial material) {
-		super(material);
+		super(Materials.getToolMaterialFor(material), null);
 		this.efficiency = material.getToolEfficiency();
 		this.setMaxDamage(material.getToolDurability());
 		this.material = material;
@@ -215,8 +217,7 @@ public class ItemMMDSickle extends GenericMMDItem implements IMMDObject {
 	@SuppressWarnings("unused")
 	public Multimap<String, AttributeModifier> getItemAttributeModifiers(
 			final EntityEquipmentSlot equipmentSlot) {
-		final Multimap<String, AttributeModifier> multimap = super.getAttributeModifiers(
-				equipmentSlot, ItemStack.EMPTY);
+		final Multimap<String, AttributeModifier> multimap = super.getItemAttributeModifiers(equipmentSlot);
 
 		// XXX: We drop the returns in booleans because it makes findbugs happy, maybe we should do
 		// something with them?


### PR DESCRIPTION
ItemMMDSickle should derive from net.minecraft.item.ItemTool instead of com.mcmoddev.lib.item.GenericMMDItem - implement this change.

ItemMMDSickle had getItemAttributeModifiers as an @Override, but was calling super.getAttributeModifiers(), leading to a circular call-chain, stack overflow and crash. Fix this by having it call the proper super method.
GenericMMDItem had some support for generic tools added during localising the bug - remove it and do a tiny bit of whitespace cleanup that was needed because of that and some other tiny bits.
GenericMMDItem has gained an import of net.minecraft.item.Item to make the class declaration a bit cleaner
com.mcmoddev.basemetals.BaseMetals had a slew of unused imports. Those have been removed.