### PR TITLE
Repair Redstone Crusher recipes

### DIFF
--- a/src/main/java/com/mcmoddev/lib/init/Recipes.java
+++ b/src/main/java/com/mcmoddev/lib/init/Recipes.java
@@ -139,7 +139,7 @@ public abstract class Recipes {
 		CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.BLOCK_LAPIS,
 				lapis.getItemStack(Names.INGOT, 9));
 
-		final MMDMaterial redstone = Materials.getMaterialByName(MaterialNames.LAPIS);
+		final MMDMaterial redstone = Materials.getMaterialByName(MaterialNames.REDSTONE);
 		CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.ORE_REDSTONE,
 				redstone.getItemStack(Names.POWDER, 8)); // Redstone Ore to 8 Redstone
 		CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.BLOCK_REDSTONE,


### PR DESCRIPTION
Instead of the non-existent Lapis Lazuli Dust, Crusher recipes with Redstone Blocks or Ores as input should have Redstone Dust as output.
(I happened to stumble upon this while troubleshooting my Destabilised Redstone issue.)