### PR TITLE
Add more Thermal Expansion Crucible recipes

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeThermalExpansion.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeThermalExpansion.java
@@ -42,7 +42,7 @@ public final class BMeThermalExpansion extends ThermalExpansion implements IInte
 				MaterialNames.ANTIMONY, MaterialNames.AQUARIUM, MaterialNames.BISMUTH,
 				MaterialNames.BRASS, MaterialNames.COLDIRON, MaterialNames.CUPRONICKEL,
 				MaterialNames.PEWTER, MaterialNames.STARSTEEL, MaterialNames.ZINC,
-				MaterialNames.MERCURY);
+				MaterialNames.MERCURY, MaterialNames.REDSTONE);
 
 		materials.stream().filter(Materials::hasMaterial)
 				.filter(materialName -> !Materials.getMaterialByName(materialName).isEmpty())

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/ThermalExpansion.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/ThermalExpansion.java
@@ -2,6 +2,7 @@ package com.mcmoddev.lib.integration.plugins;
 
 import javax.annotation.Nonnull;
 
+import com.mcmoddev.basemetals.data.MaterialNames;
 import com.mcmoddev.lib.data.Names;
 import com.mcmoddev.lib.init.Materials;
 import com.mcmoddev.lib.integration.IIntegration;
@@ -141,11 +142,18 @@ public class ThermalExpansion implements IIntegration {
 		final int ENERGY_QTY = 8000;
 
 		final String materialName = material.getName();
-		final ItemStack ingot = material.getItemStack(Names.INGOT);
-		final ItemStack dust = material.getItemStack(Names.POWDER);
-		final FluidStack oreFluid = FluidRegistry.getFluidStack(materialName, 288);
-		final FluidStack baseFluid = FluidRegistry.getFluidStack(materialName, 144);
-		final FluidStack nuggetFluid = FluidRegistry.getFluidStack(materialName, 16);
+		final FluidStack oreFluid;
+		final FluidStack baseFluid;
+		final FluidStack nuggetFluid;
+		if (materialName.equals(MaterialNames.REDSTONE)) { // Note: Redstone is and should be the only exception. Would more exceptions arise in the future, then this implementation needs to be restructured.
+			oreFluid = FluidRegistry.getFluidStack(materialName, 360);
+			baseFluid = FluidRegistry.getFluidStack(materialName, 100);
+			nuggetFluid = FluidRegistry.getFluidStack(materialName, 0); //unused in this case
+		} else {
+			oreFluid = FluidRegistry.getFluidStack(materialName, 288);
+			baseFluid = FluidRegistry.getFluidStack(materialName, 144);
+			nuggetFluid = FluidRegistry.getFluidStack(materialName, 16);
+		}
 
 		if ((material.hasBlock(Names.ORE)) && (material.getBlock(Names.ORE) != null)) {
 			final ItemStack ore = material.getBlockItemStack(Names.ORE);
@@ -153,22 +161,29 @@ public class ThermalExpansion implements IIntegration {
 		}
 
 		if (material.hasItem(Names.INGOT)) {
-			ThermalExpansionHelper.addCrucibleRecipe(ENERGY_QTY, ingot, baseFluid);
+			final ItemStack ingot = material.getItemStack(Names.INGOT);
+			ThermalExpansionHelper.addCrucibleRecipe(ENERGY_QTY / 2, ingot, baseFluid);
 		}
 
 		if (material.hasItem(Names.POWDER)) {
-			ThermalExpansionHelper.addCrucibleRecipe(ENERGY_QTY, dust, baseFluid);
+			final ItemStack dust = material.getItemStack(Names.POWDER);
+			ThermalExpansionHelper.addCrucibleRecipe(ENERGY_QTY / 4, dust, baseFluid);
 		}
 
 		if (material.hasBlock(Names.PLATE)) {
-			ThermalExpansionHelper.addCrucibleRecipe(ENERGY_QTY,
-					material.getBlockItemStack(Names.PLATE),
-					baseFluid);
+			final ItemStack plate = material.getBlockItemStack(Names.PLATE);
+			ThermalExpansionHelper.addCrucibleRecipe(ENERGY_QTY / 2,	plate, baseFluid);
 		}
 
-		if (material.hasItem(Names.NUGGET)) {
-			ThermalExpansionHelper.addCrucibleRecipe(ENERGY_QTY,
-					material.getItemStack(Names.NUGGET), nuggetFluid);
+		if (!materialName.equals(MaterialNames.REDSTONE)) { // Note: Redstone is and should be the only exception. Would more exceptions arise in the future, then this implementation needs to be restructured.
+			if (material.hasItem(Names.NUGGET)) {
+				final ItemStack nugget = material.getItemStack(Names.NUGGET);
+				ThermalExpansionHelper.addCrucibleRecipe(ENERGY_QTY / 16, nugget, nuggetFluid);
+			}
+			if (material.hasItem(Names.SMALLPOWDER)) {
+				final ItemStack smallPowder = material.getItemStack(Names.SMALLPOWDER);
+				ThermalExpansionHelper.addCrucibleRecipe(ENERGY_QTY / 32, smallPowder, nuggetFluid);
+			}
 		}
 	}
 


### PR DESCRIPTION
+Added Redstone Ore and Ingot and various Small metal Powder melting recipes to the Thermal Expansion Crucible
+Set different Thermal Expansion Crucible Energy requirements for different types of inputs
~Restructured the ThermalExpansion.addCrucible# method a bit, so the ItemStack declarations are ### **consistently** inside the conditionals per-type and declared on a separate line from the recipe creation call.

Note: The Redstone Ingot is, for as far as I know, the only Ingot that would need a Crucible crafting recipe with different fluid values, which also means that a nugget or tiny dust should not be able to be smelted.
Note2: In order to add all Tiny Piles of metal Dust to the Crucible as valid input, the Thermal Foundation metals will need to be added to the edited list in BMEThermalExpansion.java as well.