### PR TITLE
Updates the config text to reflect some of the materials already having their items in game

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
+++ b/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
@@ -205,7 +205,7 @@ public final class BMeConfig extends Config {
 				configuration.getBoolean("EnablePrismarine", VANILLA_CAT, true,
 						"Enable Prismarine Items and Materials (not currently in use)"));
 		Options.materialEnabled(MaterialNames.REDSTONE, configuration.getBoolean("EnableRedstone",
-				VANILLA_CAT, true, "Enable Redstone Items and Materials (not currently in use)"));
+				VANILLA_CAT, true, "Enable Redstone Items and Materials"));
 
 		// RECIPE AMOUNTS/TOOL&ITEM DISABLING
 		Options.setGearQuantity(configuration.getInt("Gear Quantity", TOOLS_CAT, 4, 1, 64,

--- a/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
+++ b/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
@@ -195,7 +195,7 @@ public final class BMeConfig extends Config {
 				VANILLA_CAT, true, "Enable Ender Items and Materials (not currently in use)"));
 		Options.materialEnabled(MaterialNames.QUARTZ,
 				configuration.getBoolean("EnableQuartz", VANILLA_CAT, true,
-						"Enable Nether Quartz Items and Materials (not currently in use)"));
+						"Enable Nether Quartz Items and Materials"));
 		Options.materialEnabled(MaterialNames.OBSIDIAN, configuration.getBoolean("EnableObsidian",
 				VANILLA_CAT, true, "Enable Obsidian Items and Materials"));
 		Options.materialEnabled(MaterialNames.LAPIS,

--- a/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
+++ b/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
@@ -197,7 +197,7 @@ public final class BMeConfig extends Config {
 				configuration.getBoolean("EnableQuartz", VANILLA_CAT, true,
 						"Enable Nether Quartz Items and Materials (not currently in use)"));
 		Options.materialEnabled(MaterialNames.OBSIDIAN, configuration.getBoolean("EnableObsidian",
-				VANILLA_CAT, true, "Enable Obsidian Items and Materials (not currently in use)"));
+				VANILLA_CAT, true, "Enable Obsidian Items and Materials"));
 		Options.materialEnabled(MaterialNames.LAPIS,
 				configuration.getBoolean("EnableLapis", VANILLA_CAT, true,
 						"Enable Lapis Lazuli Items and Materials (not currently in use)"));


### PR DESCRIPTION
Obsidian, Redstone and Quartz config options mentioned they were unused as the items weren't in game yet. After checking, the items do exist and most can be obtained (see #390 ). 
This also deals with a part of #222 .