### PR TITLE
Traits suggestions and Config automation

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/data/TraitNames.java
+++ b/src/main/java/com/mcmoddev/basemetals/data/TraitNames.java
@@ -199,6 +199,16 @@ public final class TraitNames {
 
 	public static final String MALLEABLE = "malleable";
 
+	public static final String MAGNETIC = "magnetic";
+
+	public static final String MAGNETIC2 = "magnetic2";
+
+	public static final String REACTIVE = "reactive";
+
+	public static final String SHOCKING = "shocking";
+
+	public static final String BRITTLE = "brittle";
+
 	private TraitNames() {
 		throw new IllegalAccessError(SharedStrings.NOT_INSTANTIABLE);
 	}

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeConstructsArmory.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeConstructsArmory.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import slimeknights.tconstruct.library.TinkerRegistry;
+import slimeknights.tconstruct.tools.TinkerTraits;
 
 import static com.mcmoddev.lib.integration.plugins.ConstructsArmory.*;
 
@@ -48,6 +49,9 @@ public final class BMeConstructsArmory implements IIntegration {
                             case MaterialNames.ADAMANTINE:
                                 addArmorTrait(mat.getTinkerMaterial(), ArmorTraits.vengeful, ArmorTraits.prideful);
                                 break;
+                            case MaterialNames.ANTIMONY:
+                                addArmorTrait(mat.getTinkerMaterial(), MMDTraitsCA.brittle);
+                                break;
                             case MaterialNames.AQUARIUM:
                                 addArmorTrait(mat.getTinkerMaterial(), ArmorTraits.rough, ArmorTraits.aquaspeed);
                                 break;
@@ -58,10 +62,14 @@ public final class BMeConstructsArmory implements IIntegration {
                                 addArmorTrait(mat.getTinkerMaterial(), MMDTraitsCA.icy);
                                 break;
                             case MaterialNames.LEAD:
-                                addArmorTrait(mat.getTinkerMaterial(), MMDTraitsCA.malleable);
+                                addArmorTrait(mat.getTinkerMaterial(), MMDTraitsCA.malleable); // Not being applied for some reason
                                 break;
                             case MaterialNames.MITHRIL:
                                 addArmorTrait(mat.getTinkerMaterial(), ArmorTraits.blessed);
+                                break;
+                            case MaterialNames.NICKEL:
+                                addArmorTrait(mat.getTinkerMaterial(), ArmorTraits.magnetic2, ArmorTraits.magnetic);
+                                addArmorTrait(mat.getTinkerMaterial(), TinkerTraits.shocking);
                                 break;
                             case MaterialNames.PEWTER:
                                 addArmorTrait(mat.getTinkerMaterial(), MMDTraitsCA.malleable);
@@ -69,6 +77,8 @@ public final class BMeConstructsArmory implements IIntegration {
                             case MaterialNames.STARSTEEL:
                                 addArmorTrait(mat.getTinkerMaterial(), MMDTraits.sparkly, ArmorTraits.enderport);
                                 break;
+                            case MaterialNames.ZINC:
+                                addArmorTrait(mat.getTinkerMaterial(), MMDTraitsCA.reactive);
                         }
                     });
         }

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeConstructsArmory.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeConstructsArmory.java
@@ -57,6 +57,9 @@ public final class BMeConstructsArmory implements IIntegration {
                             case MaterialNames.COLDIRON:
                                 addArmorTrait(mat.getTinkerMaterial(), MMDTraitsCA.icy);
                                 break;
+                            case MaterialNames.LEAD:
+                                addArmorTrait(mat.getTinkerMaterial(), MMDTraitsCA.malleable);
+                                break;
                             case MaterialNames.MITHRIL:
                                 addArmorTrait(mat.getTinkerMaterial(), ArmorTraits.blessed);
                                 break;

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeTinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeTinkersConstruct.java
@@ -25,7 +25,6 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import slimeknights.tconstruct.smeltery.TinkerSmeltery;
-import slimeknights.tconstruct.tools.TinkerTraits;
 
 import java.util.Locale;
 

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeTinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeTinkersConstruct.java
@@ -92,8 +92,8 @@ public class BMeTinkersConstruct implements IIntegration {
 		registerMaterial(MaterialNames.MITHRIL, ev,
 				TraitNames.HOLY);
 		registerMaterial(MaterialNames.NICKEL, ev,
-				TraitNames.SHOCKING, TinkerTraitLocation.HEAD,
 				TraitNames.MAGNETIC, TinkerTraitLocation.HEAD,
+				TraitNames.SHOCKING, TinkerTraitLocation.HEAD,
 				TraitNames.MAGNETIC2,
 				TraitNames.SHOCKING);
 		registerMaterial(MaterialNames.PEWTER, ev,

--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeTinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeTinkersConstruct.java
@@ -1,7 +1,5 @@
 package com.mcmoddev.basemetals.integration.plugins;
 
-import java.util.Locale;
-
 import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.basemetals.data.MaterialNames;
 import com.mcmoddev.basemetals.data.TraitNames;
@@ -18,7 +16,6 @@ import com.mcmoddev.lib.integration.plugins.tinkers.events.TinkersAlloyRecipeEve
 import com.mcmoddev.lib.integration.plugins.tinkers.events.TinkersExtraMeltingsEvent;
 import com.mcmoddev.lib.material.MMDMaterial;
 import com.mcmoddev.lib.util.Config.Options;
-
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -28,6 +25,9 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import slimeknights.tconstruct.smeltery.TinkerSmeltery;
+import slimeknights.tconstruct.tools.TinkerTraits;
+
+import java.util.Locale;
 
 import static com.mcmoddev.lib.integration.plugins.TinkersConstruct.registerBasinCasting;
 import static com.mcmoddev.lib.integration.plugins.TinkersConstruct.registerTableCasting;
@@ -74,26 +74,40 @@ public class BMeTinkersConstruct implements IIntegration {
 	@SubscribeEvent
 	public void materialRegistration(MaterialRegistrationEvent ev) {
 
-		registerMaterial(Options.isMaterialEnabled(MaterialNames.ADAMANTINE),
-				MaterialNames.ADAMANTINE, ev, TraitNames.COLDBLOODED, TraitNames.INSATIABLE);
-		registerMaterial(Options.isMaterialEnabled(MaterialNames.ANTIMONY), MaterialNames.ANTIMONY, ev);
-		registerMaterial(Options.isMaterialEnabled(MaterialNames.AQUARIUM), MaterialNames.AQUARIUM, ev,
+		registerMaterial(MaterialNames.ADAMANTINE, ev,
+				TraitNames.COLDBLOODED, TraitNames.INSATIABLE);
+		registerMaterial(MaterialNames.ANTIMONY, ev,
+				TraitNames.BRITTLE);
+		registerMaterial(MaterialNames.AQUARIUM, ev,
 				TraitNames.AQUADYNAMIC, TinkerTraitLocation.HEAD,
 				TraitNames.JAGGED, TinkerTraitLocation.HEAD,
 				TraitNames.AQUADYNAMIC);
 		registerMaterial(MaterialNames.BISMUTH, ev);
-		registerMaterial(MaterialNames.BRASS, ev, TraitNames.DENSE);
-		registerMaterial(MaterialNames.COLDIRON, ev, TraitNames.FREEZING);
+		registerMaterial(MaterialNames.BRASS, ev,
+				TraitNames.DENSE);
+		registerMaterial(MaterialNames.COLDIRON, ev,
+				TraitNames.FREEZING);
 		registerMaterial(MaterialNames.CUPRONICKEL, ev);
 		registerMaterial(MaterialNames.INVAR, ev);
-		registerMaterial(MaterialNames.MITHRIL, ev, TraitNames.HOLY);
-		registerMaterial(MaterialNames.NICKEL, ev);
-		registerMaterial(MaterialNames.PEWTER, ev, TraitNames.SOFT);
+		registerMaterial(MaterialNames.MITHRIL, ev,
+				TraitNames.HOLY);
+		registerMaterial(MaterialNames.NICKEL, ev,
+				TraitNames.SHOCKING, TinkerTraitLocation.HEAD,
+				TraitNames.MAGNETIC, TinkerTraitLocation.HEAD,
+				TraitNames.MAGNETIC2,
+				TraitNames.SHOCKING);
+		registerMaterial(MaterialNames.PEWTER, ev,
+				TraitNames.SOFT);
 		registerMaterial(MaterialNames.PLATINUM, ev);
-		registerMaterial(MaterialNames.STARSTEEL, ev, TraitNames.ENDERFERENCE,
-				TinkerTraitLocation.HEAD, TraitNames.SPARKLY);
+		registerMaterial(MaterialNames.STARSTEEL, ev,
+				TraitNames.ENDERFERENCE, TinkerTraitLocation.HEAD, TraitNames.SPARKLY);
 		registerMaterial(MaterialNames.TIN, ev);
-		registerMaterial(MaterialNames.ZINC, ev);
+		registerMaterial(MaterialNames.ZINC, ev,
+				TraitNames.REACTIVE);
+
+		// Materials already in TiC
+		registerMaterial(MaterialNames.LEAD, ev,
+				TraitNames.SOFT);
 	}
 
 	protected void registerMaterial(final String name, MaterialRegistrationEvent ev, final Object... traits){
@@ -128,7 +142,6 @@ public class BMeTinkersConstruct implements IIntegration {
 				}
 				i++;
 			}
-
 			ev.getRegistry().register(mat.create());
 		}
 	}

--- a/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
+++ b/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
@@ -1,19 +1,20 @@
 package com.mcmoddev.basemetals.util;
 
-import java.io.File;
-
 import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.basemetals.data.MaterialNames;
 import com.mcmoddev.lib.data.ConfigKeys;
 import com.mcmoddev.lib.integration.plugins.*;
 import com.mcmoddev.lib.util.Config;
-
+import com.mcmoddev.lib.util.MaterialConfigOptions;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.ConfigCategory;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.apache.commons.lang3.text.WordUtils;
+
+import java.io.File;
 
 /**
  * @author Jasmine Iwanek
@@ -25,11 +26,49 @@ public final class BMeConfig extends Config {
 	private static final String CONFIG_FILE = "config/BaseMetals.cfg";
 	private static final String GENERAL_CAT = "General";
 	private static final String INTEGRATION_CAT = "Mod Integration";
-	private static final String MATERIALS_CAT = "Metals";
-	private static final String VANILLA_CAT = "Vanilla";
 	private static final String HAMMER_RECIPES_CAT = "Crack Hammer Recipes";
 	private static final String TOOLS_CAT = "Tools and Items";
-	private static final String FLUIDS_CAT = "Fluids";
+
+	private static final MaterialConfigOptions[] MATERIAL_CONFIG_OPTIONS = new MaterialConfigOptions[]{
+		// Vanilla
+		new MaterialConfigOptions(MaterialNames.CHARCOAL, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.COAL,false, true, true,true),
+		new MaterialConfigOptions(MaterialNames.DIAMOND,true, false, true, false),
+		new MaterialConfigOptions(MaterialNames.EMERALD,true, false, true, false),
+		new MaterialConfigOptions(MaterialNames.GOLD, true,false, true, false),
+		new MaterialConfigOptions(MaterialNames.IRON, true,false, true, false),
+		new MaterialConfigOptions(MaterialNames.STONE, true,true, false, false),
+		new MaterialConfigOptions(MaterialNames.WOOD, true,true, false, false),
+		new MaterialConfigOptions(MaterialNames.ENDER, true,true, false, false),
+		new MaterialConfigOptions(MaterialNames.QUARTZ, true,true, false, false),
+		new MaterialConfigOptions(MaterialNames.OBSIDIAN,true, true, true, false),
+		new MaterialConfigOptions(MaterialNames.LAPIS, true,true, false, false),
+		new MaterialConfigOptions(MaterialNames.PRISMARINE,true, true, true, true),
+		new MaterialConfigOptions(MaterialNames.REDSTONE,true, true, true, false),
+		// Base Metals
+		new MaterialConfigOptions(MaterialNames.ADAMANTINE, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.ANTIMONY, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.AQUARIUM, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.BISMUTH, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.BRASS, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.BRONZE, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.COLDIRON, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.COPPER, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.CUPRONICKEL, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.ELECTRUM, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.INVAR, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.LEAD, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.MERCURY, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.MITHRIL, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.NICKEL, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.PEWTER, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.PLATINUM, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.SILVER, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.STARSTEEL, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.STEEL, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.TIN, false, true, true, true),
+		new MaterialConfigOptions(MaterialNames.ZINC, false, true, true, true),
+	};
 
 	/**
 	 * Fired when the configuration changes.
@@ -127,85 +166,7 @@ public final class BMeConfig extends Config {
 				"thermal_expansion", INTEGRATION_CAT, true,
 				"If Thermal Expansion is available, this wil automatically integrate materials with the various machines"));
 
-		// METALS
-		Options.materialEnabled(MaterialNames.ADAMANTINE, configuration.getBoolean(
-				"EnableAdamantine", MATERIALS_CAT, true, "Enable Adamantine Items and Materials"));
-		Options.materialEnabled(MaterialNames.ANTIMONY, configuration.getBoolean("EnableAntimony",
-				MATERIALS_CAT, true, "Enable Antimony Items and Materials"));
-		Options.materialEnabled(MaterialNames.AQUARIUM, configuration.getBoolean("EnableAquarium",
-				MATERIALS_CAT, true, "Enable Aquarium Items and Materials"));
-		Options.materialEnabled(MaterialNames.BISMUTH, configuration.getBoolean("EnableBismuth",
-				MATERIALS_CAT, true, "Enable Bismuth Items and Materials"));
-		Options.materialEnabled(MaterialNames.BRASS, configuration.getBoolean("EnableBrass",
-				MATERIALS_CAT, true, "Enable Brass Items and Materials"));
-		Options.materialEnabled(MaterialNames.BRONZE, configuration.getBoolean("EnableBronze",
-				MATERIALS_CAT, true, "Enable Bronze Items and Materials"));
-		Options.materialEnabled(MaterialNames.CHARCOAL, configuration.getBoolean("EnableCharcoal",
-				MATERIALS_CAT, true, "Enable Charcoal Items and Materials"));
-		Options.materialEnabled(MaterialNames.COAL, configuration.getBoolean("EnableCoal",
-				MATERIALS_CAT, true, "Enable Coal Items and Materials"));
-		Options.materialEnabled(MaterialNames.COLDIRON, configuration.getBoolean("EnableColdIron",
-				MATERIALS_CAT, true, "Enable ColdIron Items and Materials"));
-		Options.materialEnabled(MaterialNames.COPPER, configuration.getBoolean("EnableCopper",
-				MATERIALS_CAT, true, "Enable Copper Items and Materials"));
-		Options.materialEnabled(MaterialNames.CUPRONICKEL,
-				configuration.getBoolean("EnableCupronickel", MATERIALS_CAT, true,
-						"Enable Cupronickel Items and Materials"));
-		Options.materialEnabled(MaterialNames.ELECTRUM, configuration.getBoolean("EnableElectrum",
-				MATERIALS_CAT, true, "Enable Electrum Items and Materials"));
-		Options.materialEnabled(MaterialNames.INVAR, configuration.getBoolean("EnableInvar",
-				MATERIALS_CAT, true, "Enable Invar Items and Materials"));
-		Options.materialEnabled(MaterialNames.LEAD, configuration.getBoolean("EnableLead",
-				MATERIALS_CAT, true, "Enable Lead Items and Materials"));
-		Options.materialEnabled(MaterialNames.MERCURY, configuration.getBoolean("EnableMercury",
-				MATERIALS_CAT, true, "Enable Mercury Items and Materials"));
-		Options.materialEnabled(MaterialNames.MITHRIL, configuration.getBoolean("EnableMithril",
-				MATERIALS_CAT, true, "Enable Mithril Items and Materials"));
-		Options.materialEnabled(MaterialNames.NICKEL, configuration.getBoolean("EnableNickel",
-				MATERIALS_CAT, true, "Enable Nickel Items and Materials"));
-		Options.materialEnabled(MaterialNames.PEWTER, configuration.getBoolean("EnablePewter",
-				MATERIALS_CAT, true, "Enable Pewter Items and Materials"));
-		Options.materialEnabled(MaterialNames.PLATINUM, configuration.getBoolean("EnablePlatinum",
-				MATERIALS_CAT, true, "Enable Platinum Items and Materials"));
-		Options.materialEnabled(MaterialNames.SILVER, configuration.getBoolean("EnableSilver",
-				MATERIALS_CAT, true, "Enable Silver Items and Materials"));
-		Options.materialEnabled(MaterialNames.STARSTEEL, configuration.getBoolean("EnableStarSteel",
-				MATERIALS_CAT, true, "Enable StarSteel Items and Materials"));
-		Options.materialEnabled(MaterialNames.STEEL, configuration.getBoolean("EnableSteel",
-				MATERIALS_CAT, true, "Enable Steel Items and Materials"));
-		Options.materialEnabled(MaterialNames.TIN, configuration.getBoolean("EnableTin",
-				MATERIALS_CAT, true, "Enable Tin Items and Materials"));
-		Options.materialEnabled(MaterialNames.ZINC, configuration.getBoolean("EnableZinc",
-				MATERIALS_CAT, true, "Enable Zinc Items and Materials"));
-
-		// VANILLA
-		Options.materialEnabled(MaterialNames.DIAMOND, configuration.getBoolean("EnableDiamond",
-				VANILLA_CAT, true, "Enable Diamond Items and Materials"));
-		Options.materialEnabled(MaterialNames.EMERALD, configuration.getBoolean("EnableEmerald",
-				VANILLA_CAT, true, "Enable Emerald Items and Materials"));
-		Options.materialEnabled(MaterialNames.GOLD, configuration.getBoolean("EnableGold",
-				VANILLA_CAT, true, "Enable Gold Items and Materials"));
-		Options.materialEnabled(MaterialNames.IRON, configuration.getBoolean("EnableIron",
-				VANILLA_CAT, true, "Enable Iron Items and Materials"));
-		Options.materialEnabled(MaterialNames.STONE, configuration.getBoolean("EnableStone",
-				VANILLA_CAT, true, "Enable Stone Items and Materials"));
-		Options.materialEnabled(MaterialNames.WOOD, configuration.getBoolean("EnableWood",
-				VANILLA_CAT, true, "Enable Wood Items and Materials"));
-		Options.materialEnabled(MaterialNames.ENDER, configuration.getBoolean("EnableEnder",
-				VANILLA_CAT, true, "Enable Ender Items and Materials (not currently in use)"));
-		Options.materialEnabled(MaterialNames.QUARTZ,
-				configuration.getBoolean("EnableQuartz", VANILLA_CAT, true,
-						"Enable Nether Quartz Items and Materials"));
-		Options.materialEnabled(MaterialNames.OBSIDIAN, configuration.getBoolean("EnableObsidian",
-				VANILLA_CAT, true, "Enable Obsidian Items and Materials"));
-		Options.materialEnabled(MaterialNames.LAPIS,
-				configuration.getBoolean("EnableLapis", VANILLA_CAT, true,
-						"Enable Lapis Lazuli Items and Materials (not currently in use)"));
-		Options.materialEnabled(MaterialNames.PRISMARINE,
-				configuration.getBoolean("EnablePrismarine", VANILLA_CAT, true,
-						"Enable Prismarine Items and Materials (not currently in use)"));
-		Options.materialEnabled(MaterialNames.REDSTONE, configuration.getBoolean("EnableRedstone",
-				VANILLA_CAT, true, "Enable Redstone Items and Materials"));
+		configMaterialOptions(MATERIAL_CONFIG_OPTIONS, configuration);
 
 		// RECIPE AMOUNTS/TOOL&ITEM DISABLING
 		Options.setGearQuantity(configuration.getInt("Gear Quantity", TOOLS_CAT, 4, 1, 64,
@@ -289,70 +250,6 @@ public final class BMeConfig extends Config {
 				Options.isThingEnabled(ConfigKeys.EXPERIMENTAL));
 		Options.thingEnabled(ConfigKeys.SCYTHE,
 				configuration.getBoolean("Enable Scythe", TOOLS_CAT, false, "Enable Scythe"));
-
-		// Fluid options
-		Options.fluidEnabled("Charcoal", configuration.getBoolean("Enabled Charcoal", FLUIDS_CAT,
-				true, "Enable the molten fluid of Charcoal"));
-		Options.fluidEnabled("Coal", configuration.getBoolean("Enabled Coal", FLUIDS_CAT, true,
-				"Enable the molten fluid of Coal"));
-		Options.fluidEnabled("Diamond", configuration.getBoolean("Enabled Diamond", FLUIDS_CAT,
-				false, "Enable the molten fluid of Diamond"));
-		Options.fluidEnabled("Emerald", configuration.getBoolean("Enabled Emerald", FLUIDS_CAT,
-				false, "Enable the molten fluid of Emerald"));
-		Options.fluidEnabled("Gold", configuration.getBoolean("Enabled Gold", FLUIDS_CAT, false,
-				"Enable the molten fluid of Gold"));
-		Options.fluidEnabled("Iron", configuration.getBoolean("Enabled Iron", FLUIDS_CAT, false,
-				"Enable the molten fluid of Iron"));
-		Options.fluidEnabled("Obsidian", configuration.getBoolean("Enabled Obsidian", FLUIDS_CAT,
-				false, "Enable the molten fluid of Obsidian"));
-		Options.fluidEnabled("Prismarine", configuration.getBoolean("Enabled Prismarine",
-				FLUIDS_CAT, true, "Enable the molten fluid of Prismarine"));
-		Options.fluidEnabled("Redstone", configuration.getBoolean("Enabled Redstone", FLUIDS_CAT,
-				false, "Enable the molten fluid of Redstone"));
-		Options.fluidEnabled("Adamantine", configuration.getBoolean("Enabled Adamantine",
-				FLUIDS_CAT, true, "Enable the molten fluid of Adamantine"));
-		Options.fluidEnabled("Antimony", configuration.getBoolean("Enabled Antimony", FLUIDS_CAT,
-				true, "Enable the molten fluid of Antimony"));
-		Options.fluidEnabled("Aquarium", configuration.getBoolean("Enabled Aquarium", FLUIDS_CAT,
-				true, "Enable the molten fluid of Aquarium"));
-		Options.fluidEnabled("Bismuth", configuration.getBoolean("Enabled Bismuth", FLUIDS_CAT,
-				true, "Enable the molten fluid of Bismuth"));
-		Options.fluidEnabled("Brass", configuration.getBoolean("Enabled Brass", FLUIDS_CAT, true,
-				"Enable the molten fluid of Brass"));
-		Options.fluidEnabled("Bronze", configuration.getBoolean("Enabled Bronze", FLUIDS_CAT, true,
-				"Enable the molten fluid of Bronze"));
-		Options.fluidEnabled("ColdIron", configuration.getBoolean("Enabled ColdIron", FLUIDS_CAT,
-				true, "Enable the molten fluid of ColdIron"));
-		Options.fluidEnabled("Copper", configuration.getBoolean("Enabled Copper", FLUIDS_CAT, true,
-				"Enable the molten fluid of Copper"));
-		Options.fluidEnabled("Cupronickel", configuration.getBoolean("Enabled Cupronickel",
-				FLUIDS_CAT, true, "Enable the molten fluid of Cupronickel"));
-		Options.fluidEnabled("Electrum", configuration.getBoolean("Enabled Electrum", FLUIDS_CAT,
-				true, "Enable the molten fluid of Electrum"));
-		Options.fluidEnabled("Invar", configuration.getBoolean("Enabled Invar", FLUIDS_CAT, true,
-				"Enable the molten fluid of Invar"));
-		Options.fluidEnabled("Lead", configuration.getBoolean("Enabled Lead", FLUIDS_CAT, true,
-				"Enable the molten fluid of Lead"));
-		Options.fluidEnabled("Mercury", configuration.getBoolean("Enabled Mercury", FLUIDS_CAT, true,
-				"Enable the molten fluid of Mercury"));
-		Options.fluidEnabled("Mithril", configuration.getBoolean("Enabled Mithril", FLUIDS_CAT,
-				true, "Enable the molten fluid of Mithril"));
-		Options.fluidEnabled("Nickel", configuration.getBoolean("Enabled Nickel", FLUIDS_CAT, true,
-				"Enable the molten fluid of Nickel"));
-		Options.fluidEnabled("Pewter", configuration.getBoolean("Enabled Pewter", FLUIDS_CAT, true,
-				"Enable the molten fluid of Pewter"));
-		Options.fluidEnabled("Platinum", configuration.getBoolean("Enabled Platinum", FLUIDS_CAT,
-				true, "Enable the molten fluid of Platinum"));
-		Options.fluidEnabled("Silver", configuration.getBoolean("Enabled Silver", FLUIDS_CAT, true,
-				"Enable the molten fluid of Silver"));
-		Options.fluidEnabled("StarSteel", configuration.getBoolean("Enabled StarSteel", FLUIDS_CAT,
-				true, "Enable the molten fluid of StarSteel"));
-		Options.fluidEnabled("Steel", configuration.getBoolean("Enabled Steel", FLUIDS_CAT, true,
-				"Enable the molten fluid of Steel"));
-		Options.fluidEnabled("Tin", configuration.getBoolean("Enabled Tin", FLUIDS_CAT, true,
-				"Enable the molten fluid of Tin"));
-		Options.fluidEnabled("Zinc", configuration.getBoolean("Enabled Zinc", FLUIDS_CAT, true,
-				"Enable the molten fluid of Zinc"));
 
 		// DISABLE CRACK HAMMER RECIPES
 		Options.setDisabledRecipes(parseDisabledRecipes(configuration.getString(

--- a/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
+++ b/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
@@ -13,7 +13,6 @@ import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import slimeknights.tconstruct.tools.TinkerTraits;
 
 import java.io.File;
 
@@ -147,8 +146,7 @@ public final class BMeConfig extends Config {
 				configuration.getBoolean("Enable Mekanism Items", GENERAL_CAT, false, 
 						"Enable the items for Mekanism support even if the Mekanism plugin is disabled"));
 
-		Config.configIntegrationOptions(INTEGRATION_CONFIG_OPTIONS, configuration);
-
+		configIntegrationOptions(INTEGRATION_CONFIG_OPTIONS, configuration);
 		configMaterialOptions(MATERIAL_CONFIG_OPTIONS, configuration);
 
 		// RECIPE AMOUNTS/TOOL&ITEM DISABLING
@@ -229,10 +227,8 @@ public final class BMeConfig extends Config {
 		Options.thingEnabled(ConfigKeys.BOOKSHELF, Options.isThingEnabled(ConfigKeys.EXPERIMENTAL));
 		Options.thingEnabled(ConfigKeys.FLOWERPOT, Options.isThingEnabled(ConfigKeys.EXPERIMENTAL));
 		Options.thingEnabled(ConfigKeys.LADDER, Options.isThingEnabled(ConfigKeys.EXPERIMENTAL));
-		Options.thingEnabled(ConfigKeys.TRIPWIRE_HOOK,
-				Options.isThingEnabled(ConfigKeys.EXPERIMENTAL));
-		Options.thingEnabled(ConfigKeys.SCYTHE,
-				configuration.getBoolean("Enable Scythe", TOOLS_CAT, false, "Enable Scythe"));
+		Options.thingEnabled(ConfigKeys.TRIPWIRE_HOOK, Options.isThingEnabled(ConfigKeys.EXPERIMENTAL));
+		Options.thingEnabled(ConfigKeys.SCYTHE, configuration.getBoolean("Enable Scythe", TOOLS_CAT, false, "Enable Scythe"));
 
 		// DISABLE CRACK HAMMER RECIPES
 		Options.setDisabledRecipes(parseDisabledRecipes(configuration.getString(

--- a/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
+++ b/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
@@ -5,6 +5,7 @@ import com.mcmoddev.basemetals.data.MaterialNames;
 import com.mcmoddev.lib.data.ConfigKeys;
 import com.mcmoddev.lib.integration.plugins.*;
 import com.mcmoddev.lib.util.Config;
+import com.mcmoddev.lib.util.IntegrationConfigOptions;
 import com.mcmoddev.lib.util.MaterialConfigOptions;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.ConfigCategory;
@@ -12,7 +13,7 @@ import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.apache.commons.lang3.text.WordUtils;
+import slimeknights.tconstruct.tools.TinkerTraits;
 
 import java.io.File;
 
@@ -25,7 +26,6 @@ public final class BMeConfig extends Config {
 	private static Configuration configuration;
 	private static final String CONFIG_FILE = "config/BaseMetals.cfg";
 	private static final String GENERAL_CAT = "General";
-	private static final String INTEGRATION_CAT = "Mod Integration";
 	private static final String HAMMER_RECIPES_CAT = "Crack Hammer Recipes";
 	private static final String TOOLS_CAT = "Tools and Items";
 
@@ -68,6 +68,19 @@ public final class BMeConfig extends Config {
 		new MaterialConfigOptions(MaterialNames.STEEL, false, true, true, true),
 		new MaterialConfigOptions(MaterialNames.TIN, false, true, true, true),
 		new MaterialConfigOptions(MaterialNames.ZINC, false, true, true, true),
+	};
+
+	private static final IntegrationConfigOptions[] INTEGRATION_CONFIG_OPTIONS = new IntegrationConfigOptions[]{
+		new IntegrationConfigOptions("Ender IO", EnderIO.PLUGIN_MODID, true),
+		new IntegrationConfigOptions("IC2", IC2.PLUGIN_MODID, true),
+			new IntegrationConfigOptions("Mekanism", Mekanism.PLUGIN_MODID, true),
+			new IntegrationConfigOptions("Thaumcraft", Thaumcraft.PLUGIN_MODID, true),
+			new IntegrationConfigOptions("Tinkers Construct", TinkersConstruct.PLUGIN_MODID, true),
+			new IntegrationConfigOptions("Constructs Armory", ConstructsArmory.PLUGIN_MODID, true),
+			new IntegrationConfigOptions("VeinMiner", VeinMiner.PLUGIN_MODID, true),
+			new IntegrationConfigOptions("TAIGA", "taiga", true),
+			new IntegrationConfigOptions("Dense Ores", DenseOres.PLUGIN_MODID, true),
+			new IntegrationConfigOptions("Thermal Expansion", ThermalExpansion.PLUGIN_MODID, true)
 	};
 
 	/**
@@ -133,38 +146,8 @@ public final class BMeConfig extends Config {
 		Options.thingEnabled(ConfigKeys.MEKITEMS_WITHOUT_PLUGIN, 
 				configuration.getBoolean("Enable Mekanism Items", GENERAL_CAT, false, 
 						"Enable the items for Mekanism support even if the Mekanism plugin is disabled"));
-		
-		// INTEGRATION
-		Options.modEnabled(EnderIO.PLUGIN_MODID,
-				configuration.getBoolean("ender_io_integration", INTEGRATION_CAT, true,
-						"If false, then Base Metals will not try and integrate with Ender IO"));
-		Options.modEnabled(IC2.PLUGIN_MODID,
-				configuration.getBoolean("ic2_integration", INTEGRATION_CAT, true,
-						"If false, then Base Metals will not try and integrate with IC2"));
-		Options.modEnabled(Mekanism.PLUGIN_MODID,
-				configuration.getBoolean("mekanism_integration", INTEGRATION_CAT, true,
-						"If false, then Base Metals will not try and integrate with Mekanism"));
-		Options.modEnabled(Thaumcraft.PLUGIN_MODID,
-				configuration.getBoolean("thaumcraft_integration", INTEGRATION_CAT, true,
-						"If false, then Base Metals will not try and integrate with Thaumcraft"));
-		Options.modEnabled(TinkersConstruct.PLUGIN_MODID, configuration.getBoolean(
-				"tinkers_construct_integration", INTEGRATION_CAT, true,
-				"If false, then Base Metals will not try and integrate with Tinkers Construct"));
-		Options.modEnabled(ConstructsArmory.PLUGIN_MODID, configuration.getBoolean(
-				"constructs_armory_integration", INTEGRATION_CAT, true,
-				"If false, then Base Metals will not try and integrate with Construct's Armory"));
-		Options.modEnabled(VeinMiner.PLUGIN_MODID,
-				configuration.getBoolean("veinminer_integration", INTEGRATION_CAT, true,
-						"If false, then Base Metals will not try and integrate with VeinMiner"));
-		Options.modEnabled("taiga", configuration.getBoolean("taiga_integration",
-				INTEGRATION_CAT, true,
-				"Requires that Tinkers' Construct integration also be on. If false, TAIGA provided materials and traits will not be available in Base Metals"));
-		Options.modEnabled(DenseOres.PLUGIN_MODID,
-				configuration.getBoolean("denseores", INTEGRATION_CAT, true,
-						"If DenseOres is available, this will allow automatic integration"));
-		Options.modEnabled(ThermalExpansion.PLUGIN_MODID, configuration.getBoolean(
-				"thermal_expansion", INTEGRATION_CAT, true,
-				"If Thermal Expansion is available, this wil automatically integrate materials with the various machines"));
+
+		Config.configIntegrationOptions(INTEGRATION_CONFIG_OPTIONS, configuration);
 
 		configMaterialOptions(MATERIAL_CONFIG_OPTIONS, configuration);
 

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstruct.java
@@ -2,8 +2,6 @@ package com.mcmoddev.lib.integration.plugins;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
-import com.mcmoddev.basemetals.BaseMetals;
-import com.mcmoddev.basemetals.data.TraitNames;
 import com.mcmoddev.lib.integration.IIntegration;
 import com.mcmoddev.lib.integration.IntegrationInitEvent;
 import com.mcmoddev.lib.integration.IntegrationPostInitEvent;

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstruct.java
@@ -2,6 +2,8 @@ package com.mcmoddev.lib.integration.plugins;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import com.mcmoddev.basemetals.BaseMetals;
+import com.mcmoddev.basemetals.data.TraitNames;
 import com.mcmoddev.lib.integration.IIntegration;
 import com.mcmoddev.lib.integration.IntegrationInitEvent;
 import com.mcmoddev.lib.integration.IntegrationPostInitEvent;
@@ -170,7 +172,24 @@ public class TinkersConstruct implements IIntegration {
 
 	private void addMaterials() {
 		while(!materialsToAdd.isEmpty()) {
-			TinkerRegistry.addMaterial(materialsToAdd.pop());
+			Material material = materialsToAdd.pop();
+			if(TinkerRegistry.getMaterial(material.getIdentifier()) == Material.UNKNOWN){
+				TinkerRegistry.addMaterial(material);
+			}
+			else {
+				addExistingMaterial(material);
+			}
+		}
+	}
+
+	private void addExistingMaterial(Material material){
+		for (TinkerTraitLocation stat:TinkerTraitLocation.values()) {
+			for (ITrait trait:material.getAllTraitsForStats(stat.toString())) {
+					Material existingMaterial = TinkerRegistry.getMaterial(material.identifier);
+					if(!existingMaterial.hasTrait(trait.getIdentifier(), stat.toString())){
+						existingMaterial.addTrait(trait, stat.toString());
+					}
+			}
 		}
 	}
 	

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/armory/traits/TraitIcy.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/armory/traits/TraitIcy.java
@@ -59,9 +59,10 @@ public class TraitIcy extends AbstractArmorTrait {
 
     @Override
     public float onDamaged(ItemStack armor, EntityPlayer player, DamageSource source, float damage, float newDamage, LivingDamageEvent evt) {
+        float newNewDamage = newDamage;
         if(source.isFireDamage()){
-            newDamage = 0f;
+            newNewDamage = 0f;
         }
-        return newDamage;
+        return newNewDamage;
     }
 }

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/armory/traits/TraitIcy.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/armory/traits/TraitIcy.java
@@ -10,8 +10,9 @@ import net.minecraft.init.MobEffects;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.world.World;
+import net.minecraftforge.event.entity.living.LivingDamageEvent;
 
 /**
  * <h2><u>Icy Armor Modifier</u></h2>
@@ -56,8 +57,11 @@ public class TraitIcy extends AbstractArmorTrait {
         player.addPotionEffect(fireProtection);
     }
 
-//    @Override
-//    public void onAbilityTick(int level, World world, EntityPlayer player) {
-//        applyFireProtection(player);
-//    }
+    @Override
+    public float onDamaged(ItemStack armor, EntityPlayer player, DamageSource source, float damage, float newDamage, LivingDamageEvent evt) {
+        if(source.isFireDamage()){
+            newDamage = 0f;
+        }
+        return newDamage;
+    }
 }

--- a/src/main/java/com/mcmoddev/lib/util/Config.java
+++ b/src/main/java/com/mcmoddev/lib/util/Config.java
@@ -1,21 +1,8 @@
 package com.mcmoddev.lib.util;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.lib.data.SharedStrings;
-import com.mcmoddev.lib.integration.plugins.EnderIO;
 import com.mcmoddev.lib.registry.CrusherRecipeRegistry;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -23,6 +10,9 @@ import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.oredict.OreDictionary;
 import org.apache.commons.lang3.text.WordUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class Config {
 
@@ -39,9 +29,9 @@ public class Config {
 	}
 
 	private static void integrationEnabled(String identifier, String modid, Boolean defaultValue, Configuration configuration){
-		identifier = WordUtils.capitalizeFully(identifier);
+		String newIdentifier = WordUtils.capitalizeFully(identifier);
 		Options.modEnabled(modid,
-				configuration.getBoolean(modid + "_integration", INTEGRATION_CAT, defaultValue, "If false, then Base Metals will not try and integrate with " + identifier));
+				configuration.getBoolean(modid + "_integration", INTEGRATION_CAT, defaultValue, "If false, then Base Metals will not try and integrate with " + newIdentifier));
 	}
 
 	protected static void configIntegrationOptions(IntegrationConfigOptions[] integrationConfigOptions, Configuration configuration){
@@ -51,14 +41,14 @@ public class Config {
 	}
 
 	private static void fluidEnabled(String identifier, Boolean defaultValue, Configuration configuration){
-		identifier = WordUtils.capitalizeFully(identifier);
-		Options.fluidEnabled(identifier, configuration.getBoolean("Enables " + identifier, FLUIDS_CAT, defaultValue, "Enables the molten fluid of " + identifier));
+		String newIdentifier = WordUtils.capitalizeFully(identifier);
+		Options.fluidEnabled(newIdentifier, configuration.getBoolean("Enables " + identifier, FLUIDS_CAT, defaultValue, "Enables the molten fluid of " + identifier));
 	}
 
 	private static void materialEnabled(String identifier, Boolean defaultValue, Boolean isVanilla, Configuration configuration){
-		identifier = WordUtils.capitalizeFully(identifier);
+		String newIdentifier = WordUtils.capitalizeFully(identifier);
 		String cat = isVanilla ? VANILLA_CAT : MATERIALS_CAT;
-		Options.materialEnabled(identifier, configuration.getBoolean("Enables " + identifier, cat, defaultValue, "Enables " + identifier + " Items and Materials"));
+		Options.materialEnabled(newIdentifier, configuration.getBoolean("Enables " + identifier, cat, defaultValue, "Enables " + newIdentifier + " Items and Materials"));
 	}
 
 	protected static void configMaterialOptions(MaterialConfigOptions[] materials, Configuration configuration){

--- a/src/main/java/com/mcmoddev/lib/util/Config.java
+++ b/src/main/java/com/mcmoddev/lib/util/Config.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.lib.data.SharedStrings;
+import com.mcmoddev.lib.integration.plugins.EnderIO;
 import com.mcmoddev.lib.registry.CrusherRecipeRegistry;
 
 import net.minecraft.block.Block;
@@ -28,6 +29,7 @@ public class Config {
 	private static final String FLUIDS_CAT = "Fluids";
 	private static final String MATERIALS_CAT = "Metals";
 	private static final String VANILLA_CAT = "Vanilla";
+	private static final String INTEGRATION_CAT = "Mod Integration";
 
 	private static final List<String> UserCrusherRecipes = new ArrayList<>();
 
@@ -36,12 +38,24 @@ public class Config {
 
 	}
 
-	protected static void fluidEnabled(String identifier, Boolean defaultValue, Configuration configuration){
+	private static void integrationEnabled(String identifier, String modid, Boolean defaultValue, Configuration configuration){
+		identifier = WordUtils.capitalizeFully(identifier);
+		Options.modEnabled(modid,
+				configuration.getBoolean(modid + "_integration", INTEGRATION_CAT, defaultValue, "If false, then Base Metals will not try and integrate with " + identifier));
+	}
+
+	protected static void configIntegrationOptions(IntegrationConfigOptions[] integrationConfigOptions, Configuration configuration){
+		for (IntegrationConfigOptions integration:integrationConfigOptions) {
+			integrationEnabled(integration.getIdentifier(), integration.getModid(), integration.getEnabled(), configuration);
+		}
+	}
+
+	private static void fluidEnabled(String identifier, Boolean defaultValue, Configuration configuration){
 		identifier = WordUtils.capitalizeFully(identifier);
 		Options.fluidEnabled(identifier, configuration.getBoolean("Enables " + identifier, FLUIDS_CAT, defaultValue, "Enables the molten fluid of " + identifier));
 	}
 
-	protected static void materialEnabled(String identifier, Boolean defaultValue, Boolean isVanilla, Configuration configuration){
+	private static void materialEnabled(String identifier, Boolean defaultValue, Boolean isVanilla, Configuration configuration){
 		identifier = WordUtils.capitalizeFully(identifier);
 		String cat = isVanilla ? VANILLA_CAT : MATERIALS_CAT;
 		Options.materialEnabled(identifier, configuration.getBoolean("Enables " + identifier, cat, defaultValue, "Enables " + identifier + " Items and Materials"));

--- a/src/main/java/com/mcmoddev/lib/util/Config.java
+++ b/src/main/java/com/mcmoddev/lib/util/Config.java
@@ -18,16 +18,42 @@ import com.mcmoddev.lib.registry.CrusherRecipeRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.oredict.OreDictionary;
+import org.apache.commons.lang3.text.WordUtils;
 
 public class Config {
+
+	private static final String FLUIDS_CAT = "Fluids";
+	private static final String MATERIALS_CAT = "Metals";
+	private static final String VANILLA_CAT = "Vanilla";
 
 	private static final List<String> UserCrusherRecipes = new ArrayList<>();
 
 	// shut up SonarLint/SonarQube
 	protected Config() {
 
+	}
+
+	protected static void fluidEnabled(String identifier, Boolean defaultValue, Configuration configuration){
+		identifier = WordUtils.capitalizeFully(identifier);
+		Options.fluidEnabled(identifier, configuration.getBoolean("Enables " + identifier, FLUIDS_CAT, defaultValue, "Enables the molten fluid of " + identifier));
+	}
+
+	protected static void materialEnabled(String identifier, Boolean defaultValue, Boolean isVanilla, Configuration configuration){
+		identifier = WordUtils.capitalizeFully(identifier);
+		String cat = isVanilla ? VANILLA_CAT : MATERIALS_CAT;
+		Options.materialEnabled(identifier, configuration.getBoolean("Enables " + identifier, cat, defaultValue, "Enables " + identifier + " Items and Materials"));
+	}
+
+	protected static void configMaterialOptions(MaterialConfigOptions[] materials, Configuration configuration){
+		for (MaterialConfigOptions materialConfigOptions:materials) {
+			materialEnabled(materialConfigOptions.getIdentifier(), materialConfigOptions.getMaterialEnabled(), materialConfigOptions.getVanilla(), configuration);
+			if(materialConfigOptions.getHasFluid()){
+				fluidEnabled(materialConfigOptions.getIdentifier(), materialConfigOptions.getFluidEnabled(), configuration);
+			}
+		}
 	}
 
 	protected static void manageUserHammerRecipes(final Collection<Property> values) {

--- a/src/main/java/com/mcmoddev/lib/util/IntegrationConfigOptions.java
+++ b/src/main/java/com/mcmoddev/lib/util/IntegrationConfigOptions.java
@@ -1,0 +1,25 @@
+package com.mcmoddev.lib.util;
+
+public class IntegrationConfigOptions {
+    private String identifier;
+    private String modid;
+    private Boolean isEnabled;
+
+    public IntegrationConfigOptions(String identifier, String modid, Boolean isMaterialEnabled) {
+        this.identifier = identifier;
+        this.modid = modid;
+        this.isEnabled = isMaterialEnabled;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public String getModid() {
+        return modid;
+    }
+
+    public Boolean getEnabled() {
+        return isEnabled;
+    }
+}

--- a/src/main/java/com/mcmoddev/lib/util/MaterialConfigOptions.java
+++ b/src/main/java/com/mcmoddev/lib/util/MaterialConfigOptions.java
@@ -1,0 +1,37 @@
+package com.mcmoddev.lib.util;
+
+public class MaterialConfigOptions{
+    private String identifier;
+    private Boolean isVanilla;
+    private Boolean isMaterialEnabled;
+    private Boolean hasFluid;
+    private Boolean isFluidEnabled;
+
+    public MaterialConfigOptions(String identifier, Boolean isVanilla, Boolean isMaterialEnabled, Boolean hasFluid, Boolean isFluidEnabled) {
+        this.identifier = identifier;
+        this.isVanilla = isVanilla;
+        this.isMaterialEnabled = isMaterialEnabled;
+        this.hasFluid = hasFluid;
+        this.isFluidEnabled = isFluidEnabled;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public Boolean getVanilla() {
+        return isVanilla;
+    }
+
+    public Boolean getMaterialEnabled() {
+        return isMaterialEnabled;
+    }
+
+    public Boolean getHasFluid() {
+        return hasFluid;
+    }
+
+    public Boolean getFluidEnabled() {
+        return isFluidEnabled;
+    }
+}


### PR DESCRIPTION
Added traits for Antimony, Nickel and Zinc for both TiC and ConArm;
Added an extra trait to Lead for TiC;

Automated the Config options for Vanilla Materials, Metals and Fluids;
Automated the Config options for Mod Integrations;

Any add-on to BaseMetals can take advantage of this through usage of `lib\util\Config.java`, specifically through:
- `configIntegrationOptions(...)`;
- `configMaterialOptions(...)`;