### PR TITLE
More proper decoupling of MMDLib and BaseMetals

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeTinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/BMeTinkersConstruct.java
@@ -86,7 +86,9 @@ public class BMeTinkersConstruct implements IIntegration {
 	
 	@SubscribeEvent
 	public void postInit(final IntegrationPostInitEvent event){
-		registerPrismarineFullCasting();
+		if(Options.isMaterialEnabled(MaterialNames.PRISMARINE) && Options.isFluidEnabled(MaterialNames.PRISMARINE)) {
+			registerPrismarineFullCasting();
+		}
 	}
 
 	public static void registerPrismarineFullCasting(){

--- a/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
+++ b/src/main/java/com/mcmoddev/basemetals/util/BMeConfig.java
@@ -45,20 +45,6 @@ public final class BMeConfig extends Config {
 		new MaterialConfigOptions(MaterialNames.STEEL, false, true, true, true, true),
 		new MaterialConfigOptions(MaterialNames.TIN, false, true, true, true, true),
 		new MaterialConfigOptions(MaterialNames.ZINC, false, true, true, true, true),
-		new MaterialConfigOptions(MaterialNames.CHARCOAL, true, true, true, true),
-		new MaterialConfigOptions(MaterialNames.COAL, true, true, true,true),
-		new MaterialConfigOptions(MaterialNames.DIAMOND,true, true, true, true),
-		new MaterialConfigOptions(MaterialNames.EMERALD,true, true, true, true),
-		new MaterialConfigOptions(MaterialNames.GOLD, true,true, true, true),
-		new MaterialConfigOptions(MaterialNames.IRON, true,true, true, true),
-		new MaterialConfigOptions(MaterialNames.STONE, true,true, false, false),
-		new MaterialConfigOptions(MaterialNames.WOOD, true,true, false, false),
-		new MaterialConfigOptions(MaterialNames.ENDER, true,true, true, true),
-		new MaterialConfigOptions(MaterialNames.QUARTZ, true,true, true, true),
-		new MaterialConfigOptions(MaterialNames.OBSIDIAN,true, true, true, true),
-		new MaterialConfigOptions(MaterialNames.LAPIS, true,true, false, false),
-		new MaterialConfigOptions(MaterialNames.PRISMARINE,true, true, true, true),
-		new MaterialConfigOptions(MaterialNames.REDSTONE,true, true, true, true)
 	};
 
 	/**

--- a/src/main/java/com/mcmoddev/basemetals/util/EventHandler.java
+++ b/src/main/java/com/mcmoddev/basemetals/util/EventHandler.java
@@ -2,6 +2,7 @@ package com.mcmoddev.basemetals.util;
 
 import javax.annotation.Nonnull;
 
+import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.basemetals.init.Fluids;
 import com.mcmoddev.basemetals.properties.AdamantineProperty;
 import com.mcmoddev.basemetals.properties.AdamantineToolProperty;
@@ -46,7 +47,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@EventBusSubscriber
+@EventBusSubscriber(modid=BaseMetals.MODID)
 public final class EventHandler {
 
 	public EventHandler() {
@@ -183,18 +184,6 @@ public final class EventHandler {
 		if(FMLCommonHandler.instance().getEffectiveSide() ==  Side.CLIENT) {
 			com.mcmoddev.basemetals.init.Materials.initTooltips();			
 		}
-	}
-
-	/*
-	 * @SubscribeEvent public static void mmdlibRegisterBlocks(final
-	 * MMDLibRegisterBlocks event) { Blocks.init(event); }
-	 * 
-	 * @SubscribeEvent public static void mmdlibRegisterItems(final
-	 * MMDLibRegisterItems event) { Items.registerItems(event); }
-	 */
-	@SubscribeEvent
-	public static void mmdlibRegisterFluids(final MMDLibRegisterFluids event) {
-		Fluids.registerEvent(event);
 	}
 	
 	@SubscribeEvent

--- a/src/main/java/com/mcmoddev/basemetals/vanillabits/VanillaBlocks.java
+++ b/src/main/java/com/mcmoddev/basemetals/vanillabits/VanillaBlocks.java
@@ -13,7 +13,6 @@ import com.mcmoddev.lib.material.MMDMaterial;
 import com.mcmoddev.lib.util.Config.Options;
 
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @Mod.EventBusSubscriber(modid=BaseMetals.MODID)
@@ -23,53 +22,13 @@ public class VanillaBlocks extends Blocks {
 		throw new IllegalAccessError("Class cannot be instantiated!");
 	}
 
-	@SubscribeEvent(priority=EventPriority.HIGHEST)
+	@SubscribeEvent
 	public static void registerVanilla(MMDLibRegisterBlocks ev) {
 		// Vanilla Materials get their Ore and Block always
 		final MMDMaterial charcoal = Materials.getMaterialByName(MaterialNames.CHARCOAL);
-		final MMDMaterial coal = Materials.getMaterialByName(MaterialNames.COAL);
-		final MMDMaterial diamond = Materials.getMaterialByName(MaterialNames.DIAMOND);
-		final MMDMaterial emerald = Materials.getMaterialByName(MaterialNames.EMERALD);
 		final MMDMaterial gold = Materials.getMaterialByName(MaterialNames.GOLD);
 		final MMDMaterial iron = Materials.getMaterialByName(MaterialNames.IRON);
-		final MMDMaterial lapis = Materials.getMaterialByName(MaterialNames.LAPIS);
-		final MMDMaterial obsidian = Materials.getMaterialByName(MaterialNames.OBSIDIAN);
 		final MMDMaterial quartz = Materials.getMaterialByName(MaterialNames.QUARTZ);
-		final MMDMaterial redstone = Materials.getMaterialByName(MaterialNames.REDSTONE);
-
-		coal.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.COAL_BLOCK);
-		coal.addNewBlock(Names.ORE, net.minecraft.init.Blocks.COAL_ORE);
-
-		diamond.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.DIAMOND_BLOCK);
-		diamond.addNewBlock(Names.ORE, net.minecraft.init.Blocks.DIAMOND_ORE);
-
-		emerald.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.EMERALD_BLOCK);
-		emerald.addNewBlock(Names.ORE, net.minecraft.init.Blocks.EMERALD_ORE);
-
-		gold.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.GOLD_BLOCK);
-		gold.addNewBlock(Names.ORE, net.minecraft.init.Blocks.GOLD_ORE);
-		gold.addNewBlock(Names.PRESSURE_PLATE,
-				net.minecraft.init.Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE);
-
-		iron.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.IRON_BLOCK);
-		iron.addNewBlock(Names.ORE, net.minecraft.init.Blocks.IRON_ORE);
-		iron.addNewBlock(Names.BARS, net.minecraft.init.Blocks.IRON_BARS);
-		iron.addNewBlock(Names.DOOR, net.minecraft.init.Blocks.IRON_DOOR);
-		iron.addNewBlock(Names.TRAPDOOR, net.minecraft.init.Blocks.IRON_TRAPDOOR);
-		iron.addNewBlock(Names.PRESSURE_PLATE,
-				net.minecraft.init.Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE);
-
-		lapis.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.LAPIS_BLOCK);
-		lapis.addNewBlock(Names.ORE, net.minecraft.init.Blocks.LAPIS_ORE);
-
-		obsidian.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.OBSIDIAN);
-
-		quartz.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.QUARTZ_BLOCK);
-		quartz.addNewBlock(Names.ORE, net.minecraft.init.Blocks.QUARTZ_ORE);
-		quartz.addNewBlock(Names.STAIRS, net.minecraft.init.Blocks.QUARTZ_STAIRS);
-
-		redstone.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.REDSTONE_BLOCK);
-		redstone.addNewBlock(Names.ORE, net.minecraft.init.Blocks.REDSTONE_ORE);
 
 		if (Materials.hasMaterial(MaterialNames.CHARCOAL)) {
 			create(Names.BLOCK, charcoal);

--- a/src/main/java/com/mcmoddev/basemetals/vanillabits/VanillaItems.java
+++ b/src/main/java/com/mcmoddev/basemetals/vanillabits/VanillaItems.java
@@ -11,13 +11,9 @@ import com.mcmoddev.lib.events.MMDLibRegisterItems;
 import com.mcmoddev.lib.init.Materials;
 import com.mcmoddev.lib.material.IMMDBurnableObject;
 import com.mcmoddev.lib.material.MMDMaterial;
-//import com.mcmoddev.lib.util.Config;
 import com.mcmoddev.lib.util.Config.Options;
 
-import net.minecraft.item.ItemStack;
-
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @Mod.EventBusSubscriber(modid=BaseMetals.MODID)
@@ -27,21 +23,8 @@ public class VanillaItems extends com.mcmoddev.lib.init.Items {
 		// TODO Auto-generated constructor stub
 	}
 	
-	@SubscribeEvent(priority=EventPriority.HIGHEST)
+	@SubscribeEvent
 	public static void registerItemsEvent(MMDLibRegisterItems ev) {
-		Materials.getMaterialByName(MaterialNames.CHARCOAL).addNewItemFromItemStack(Names.INGOT,
-				new ItemStack(net.minecraft.init.Items.COAL, 1, 1));
-		Materials.getMaterialByName(MaterialNames.COAL).addNewItemFromItemStack(Names.INGOT,
-				new ItemStack(net.minecraft.init.Items.COAL, 1, 0));
-
-		Materials.getMaterialByName(MaterialNames.EMERALD).addNewItem(Names.INGOT,
-				net.minecraft.init.Items.EMERALD);
-		Materials.getMaterialByName(MaterialNames.LAPIS).addNewItemFromItemStack(Names.INGOT,
-				new ItemStack(net.minecraft.init.Items.DYE, 1, 4));
-		Materials.getMaterialByName(MaterialNames.QUARTZ).addNewItem(Names.INGOT,
-				net.minecraft.init.Items.QUARTZ);
-		Materials.getMaterialByName(MaterialNames.REDSTONE).addNewItem(Names.POWDER,
-				net.minecraft.init.Items.REDSTONE);
 		addDiamondBits();
 		addGoldBits();
 		addIronBits();
@@ -172,18 +155,6 @@ public class VanillaItems extends com.mcmoddev.lib.init.Items {
 	private static void addDiamondBits() {
 		final MMDMaterial diamond = Materials.getMaterialByName(MaterialNames.DIAMOND);
 
-		diamond.addNewItem(Names.AXE, net.minecraft.init.Items.DIAMOND_AXE);
-		diamond.addNewItem(Names.HOE, net.minecraft.init.Items.DIAMOND_HOE);
-		diamond.addNewItem(Names.HORSE_ARMOR, net.minecraft.init.Items.DIAMOND_HORSE_ARMOR);
-		diamond.addNewItem(Names.PICKAXE, net.minecraft.init.Items.DIAMOND_PICKAXE);
-		diamond.addNewItem(Names.SHOVEL, net.minecraft.init.Items.DIAMOND_SHOVEL);
-		diamond.addNewItem(Names.SWORD, net.minecraft.init.Items.DIAMOND_SWORD);
-		diamond.addNewItem(Names.BOOTS, net.minecraft.init.Items.DIAMOND_BOOTS);
-		diamond.addNewItem(Names.CHESTPLATE, net.minecraft.init.Items.DIAMOND_CHESTPLATE);
-		diamond.addNewItem(Names.HELMET, net.minecraft.init.Items.DIAMOND_HELMET);
-		diamond.addNewItem(Names.LEGGINGS, net.minecraft.init.Items.DIAMOND_LEGGINGS);
-		diamond.addNewItem(Names.INGOT, net.minecraft.init.Items.DIAMOND);
-
 		if (Materials.hasMaterial(MaterialNames.DIAMOND)) {
 			create(Names.BLEND, diamond);
 			create(Names.NUGGET, diamond);
@@ -210,19 +181,6 @@ public class VanillaItems extends com.mcmoddev.lib.init.Items {
 	private static void addGoldBits() {
 		final MMDMaterial gold = Materials.getMaterialByName(MaterialNames.GOLD);
 
-		gold.addNewItem(Names.AXE, net.minecraft.init.Items.GOLDEN_AXE);
-		gold.addNewItem(Names.HOE, net.minecraft.init.Items.GOLDEN_HOE);
-		gold.addNewItem(Names.HORSE_ARMOR, net.minecraft.init.Items.GOLDEN_HORSE_ARMOR);
-		gold.addNewItem(Names.PICKAXE, net.minecraft.init.Items.GOLDEN_PICKAXE);
-		gold.addNewItem(Names.SHOVEL, net.minecraft.init.Items.GOLDEN_SHOVEL);
-		gold.addNewItem(Names.SWORD, net.minecraft.init.Items.GOLDEN_SWORD);
-		gold.addNewItem(Names.BOOTS, net.minecraft.init.Items.GOLDEN_BOOTS);
-		gold.addNewItem(Names.CHESTPLATE, net.minecraft.init.Items.GOLDEN_CHESTPLATE);
-		gold.addNewItem(Names.HELMET, net.minecraft.init.Items.GOLDEN_HELMET);
-		gold.addNewItem(Names.LEGGINGS, net.minecraft.init.Items.GOLDEN_LEGGINGS);
-		gold.addNewItem(Names.INGOT, net.minecraft.init.Items.GOLD_INGOT);
-		gold.addNewItem(Names.NUGGET, net.minecraft.init.Items.GOLD_NUGGET);
-
 		if (Materials.hasMaterial(MaterialNames.GOLD)) {
 			create(Names.BLEND, gold);
 			create(Names.POWDER, gold);
@@ -247,21 +205,6 @@ public class VanillaItems extends com.mcmoddev.lib.init.Items {
 
 	private static void addIronBits() {
 		final MMDMaterial iron = Materials.getMaterialByName(MaterialNames.IRON);
-
-		iron.addNewItem(Names.AXE, net.minecraft.init.Items.IRON_AXE);
-		iron.addNewItem(Names.DOOR, net.minecraft.init.Items.IRON_DOOR);
-		iron.addNewItem(Names.HOE, net.minecraft.init.Items.IRON_HOE);
-		iron.addNewItem(Names.HORSE_ARMOR, net.minecraft.init.Items.IRON_HORSE_ARMOR);
-		iron.addNewItem(Names.PICKAXE, net.minecraft.init.Items.IRON_PICKAXE);
-		iron.addNewItem(Names.SHOVEL, net.minecraft.init.Items.IRON_SHOVEL);
-		iron.addNewItem(Names.SWORD, net.minecraft.init.Items.IRON_SWORD);
-		iron.addNewItem(Names.BOOTS, net.minecraft.init.Items.IRON_BOOTS);
-		iron.addNewItem(Names.CHESTPLATE, net.minecraft.init.Items.IRON_CHESTPLATE);
-		iron.addNewItem(Names.HELMET, net.minecraft.init.Items.IRON_HELMET);
-		iron.addNewItem(Names.LEGGINGS, net.minecraft.init.Items.IRON_LEGGINGS);
-		iron.addNewItem(Names.INGOT, net.minecraft.init.Items.IRON_INGOT);
-		iron.addNewItem(Names.NUGGET, net.minecraft.init.Items.IRON_NUGGET);
-		iron.addNewItem(Names.SHEARS, net.minecraft.init.Items.SHEARS);
 
 		if (Materials.hasMaterial(MaterialNames.IRON)) {
 			create(Names.BLEND, iron);
@@ -299,16 +242,6 @@ public class VanillaItems extends com.mcmoddev.lib.init.Items {
 	private static void addStoneBits() {
 		final MMDMaterial stone = Materials.getMaterialByName(MaterialNames.STONE);
 
-		stone.addNewItem(Names.AXE, net.minecraft.init.Items.STONE_AXE);
-		stone.addNewItem(Names.HOE, net.minecraft.init.Items.STONE_HOE);
-		stone.addNewItem(Names.PICKAXE, net.minecraft.init.Items.STONE_PICKAXE);
-		stone.addNewItem(Names.SHOVEL, net.minecraft.init.Items.STONE_SHOVEL);
-		stone.addNewItem(Names.SWORD, net.minecraft.init.Items.STONE_SWORD);
-		stone.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.STONE);
-		stone.addNewBlock(Names.SLAB, net.minecraft.init.Blocks.STONE_SLAB);
-		stone.addNewBlock(Names.DOUBLE_SLAB, net.minecraft.init.Blocks.DOUBLE_STONE_SLAB);
-		stone.addNewBlock(Names.STAIRS, net.minecraft.init.Blocks.STONE_STAIRS);
-
 		if (Materials.hasMaterial(MaterialNames.STONE)) {
 			create(Names.CRACKHAMMER, stone);
 			create(Names.ROD, stone);
@@ -320,21 +253,6 @@ public class VanillaItems extends com.mcmoddev.lib.init.Items {
 	private static void addWoodBits() {
 		final MMDMaterial wood = Materials.getMaterialByName(MaterialNames.WOOD);
 
-		wood.addNewItem(Names.AXE, net.minecraft.init.Items.WOODEN_AXE);
-		wood.addNewItem(Names.DOOR, net.minecraft.init.Items.OAK_DOOR);
-		wood.addNewItem(Names.HOE, net.minecraft.init.Items.WOODEN_HOE);
-		wood.addNewItem(Names.PICKAXE, net.minecraft.init.Items.WOODEN_PICKAXE);
-		wood.addNewItem(Names.SHOVEL, net.minecraft.init.Items.WOODEN_SHOVEL);
-		wood.addNewItem(Names.SWORD, net.minecraft.init.Items.WOODEN_SWORD);
-		wood.addNewBlock(Names.DOOR, net.minecraft.init.Blocks.OAK_DOOR);
-		wood.addNewBlock(Names.ORE, net.minecraft.init.Blocks.LOG);
-		wood.addNewBlock(Names.TRAPDOOR, net.minecraft.init.Blocks.TRAPDOOR);
-		wood.addNewBlock(Names.BLOCK, net.minecraft.init.Blocks.PLANKS);
-		wood.addNewBlock(Names.SLAB, net.minecraft.init.Blocks.WOODEN_SLAB);
-		wood.addNewBlock(Names.DOUBLE_SLAB, net.minecraft.init.Blocks.DOUBLE_WOODEN_SLAB);
-		wood.addNewBlock(Names.STAIRS, net.minecraft.init.Blocks.OAK_STAIRS);
-		wood.addNewItem(Names.SHEARS, net.minecraft.init.Items.SHEARS);
-		
 		if (Materials.hasMaterial(MaterialNames.WOOD)) {
 			create(Names.CRACKHAMMER, wood);
 			create(Names.GEAR, wood);


### PR DESCRIPTION
1) Move adding existing items for vanilla stuff to MMDLib
2) Move adding existing blocks for vanilla stuff to MMDLib
3) Move configuring "vanilla materials" on/off to MMDLib
-- This allows for MMDLib to provide for access to existing vanilla stuff
without providing anything extra