### PR TITLE
Add guarded Base Metals release dispatcher

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,541 @@
+name: Release Base Metals
+
+run-name: Release Base Metals ${{ inputs.release_version }} (CurseForge ${{ inputs.curseforge_release_level }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: Four-component Base Metals version; the target branch is derived from its fourth component.
+        required: true
+        type: string
+      curseforge_release_level:
+        description: CurseForge release level only; this does not change the GitHub Release type.
+        required: true
+        default: release
+        type: choice
+        options:
+          - release
+          - beta
+          - alpha
+      confirm_live_publication:
+        description: Confirm publication to Maven, CurseForge, and GitHub after the build passes.
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: basemetals-release-${{ inputs.release_version }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Validate release request
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      target_branch: ${{ steps.route.outputs.target_branch }}
+      release_sha: ${{ steps.validate.outputs.release_sha }}
+      release_version: ${{ steps.validate.outputs.release_version }}
+      release_tag: ${{ steps.validate.outputs.release_tag }}
+      minecraft_version: ${{ steps.validate.outputs.minecraft_version }}
+      loader_name: ${{ steps.validate.outputs.loader_name }}
+      loader_display: ${{ steps.validate.outputs.loader_display }}
+      java_version: ${{ steps.validate.outputs.java_version }}
+      java_toolchain_version: ${{ steps.validate.outputs.java_toolchain_version }}
+      gradle_java_version: ${{ steps.validate.outputs.gradle_java_version }}
+      curseforge_project_id: ${{ steps.validate.outputs.curseforge_project_id }}
+      main_jar: ${{ steps.validate.outputs.main_jar }}
+      sources_jar: ${{ steps.validate.outputs.sources_jar }}
+      javadoc_jar: ${{ steps.validate.outputs.javadoc_jar }}
+
+    steps:
+      - name: Resolve target branch from version
+        id: route
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_REPOSITORY" != "MinecraftModDevelopmentMods/BaseMetals" ]]; then
+            echo "Releases can only run in MinecraftModDevelopmentMods/BaseMetals" >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.([0-9]+)$ ]]; then
+            echo "release_version must contain four numeric components" >&2
+            exit 1
+          fi
+
+          target_suffix="${BASH_REMATCH[1]}"
+          if (( ${#target_suffix} < 6 )); then
+            echo "Invalid target suffix $target_suffix" >&2
+            exit 1
+          fi
+
+          loader_code="${target_suffix: -1}"
+          target_digits="${target_suffix::-1}"
+          mc_patch_padded="${target_digits: -2}"
+          without_patch="${target_digits::-2}"
+          mc_minor_padded="${without_patch: -2}"
+          mc_major="${without_patch::-2}"
+
+          if [[ -z "$mc_major" || ! "$mc_major" =~ ^[0-9]+$ ]]; then
+            echo "Invalid Minecraft major version in target suffix $target_suffix" >&2
+            exit 1
+          fi
+          mc_minor="$((10#$mc_minor_padded))"
+          mc_patch="$((10#$mc_patch_padded))"
+          case "$loader_code" in
+            1) loader_suffix= ;;
+            2) loader_suffix=-neo ;;
+            *) echo "Unknown loader code $loader_code in target suffix $target_suffix" >&2; exit 1 ;;
+          esac
+
+          candidates=(
+            "master-$mc_major.$mc_minor.$mc_patch$loader_suffix"
+            "master-$mc_major.$mc_minor$loader_suffix"
+          )
+          target_branch=
+          for candidate in "${candidates[@]}"; do
+            if gh api "repos/$GITHUB_REPOSITORY/branches/$candidate" >/dev/null 2>&1; then
+              target_branch="$candidate"
+              break
+            fi
+          done
+          if [[ -z "$target_branch" ]]; then
+            echo "No MMD release branch matches target suffix $target_suffix" >&2
+            printf 'Checked branch %s\n' "${candidates[@]}" >&2
+            exit 1
+          fi
+
+          echo "target_branch=$target_branch" >> "$GITHUB_OUTPUT"
+          echo "Resolved $RELEASE_VERSION to $target_branch"
+
+      - name: Check out derived release branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ steps.route.outputs.target_branch }}
+          fetch-depth: 0
+
+      - name: Validate version, target, tag, and prior CI
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+
+          value() { sed -n "s/^$1=//p" gradle.properties; }
+          release_version="$(value mod_version)"
+          minecraft_version="$(value minecraft_version)"
+          loader_name="$(value loader_name)"
+          loader_code="$(value loader_code)"
+          java_version="$(value java_version)"
+          java_toolchain_version="$(value java_toolchain_version)"
+          gradle_java_version="$(value gradle_java_version)"
+          curseforge_project_id="$(value curseforge_project_id)"
+
+          for required in release_version minecraft_version loader_name loader_code \
+              java_version gradle_java_version curseforge_project_id; do
+            if [[ -z "${!required}" ]]; then
+              echo "Selected ref is missing required release metadata: $required" >&2
+              exit 1
+            fi
+          done
+          java_toolchain_version="${java_toolchain_version:-$java_version}"
+
+          IFS=. read -r mc_major mc_minor mc_patch extra <<<"$minecraft_version"
+          if [[ -n "${extra:-}" || -z "${mc_major:-}" || -z "${mc_minor:-}" ]]; then
+            echo "Invalid minecraft_version=$minecraft_version" >&2
+            exit 1
+          fi
+          mc_patch="${mc_patch:-0}"
+          if [[ ! "$mc_major" =~ ^[0-9]+$ || ! "$mc_minor" =~ ^[0-9]+$ || ! "$mc_patch" =~ ^[0-9]+$ ]]; then
+            echo "Invalid minecraft_version=$minecraft_version" >&2
+            exit 1
+          fi
+          case "$loader_name:$loader_code" in
+            forge:1) loader_display=Forge ;;
+            neoforge:2) loader_display=NeoForge ;;
+            *) echo "Invalid loader metadata $loader_name/$loader_code" >&2; exit 1 ;;
+          esac
+          if [[ ! "$java_version" =~ ^[0-9]+$ || ! "$gradle_java_version" =~ ^[0-9]+$ ]]; then
+            echo "Invalid Java metadata $java_version/$gradle_java_version" >&2
+            exit 1
+          fi
+          if [[ "$curseforge_project_id" != "240967" ]]; then
+            echo "Unexpected Base Metals CurseForge project $curseforge_project_id" >&2
+            exit 1
+          fi
+
+          printf -v minor_padded '%02d' "$((10#$mc_minor))"
+          printf -v patch_padded '%02d' "$((10#$mc_patch))"
+          target_suffix="${mc_major}${minor_padded}${patch_padded}${loader_code}"
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.${target_suffix}$ ]]; then
+            echo "mod_version $release_version does not match $minecraft_version $loader_display target $target_suffix" >&2
+            exit 1
+          fi
+          if [[ "$REQUESTED_VERSION" != "$release_version" ]]; then
+            echo "Requested version $REQUESTED_VERSION does not match ${{ steps.route.outputs.target_branch }} mod_version $release_version" >&2
+            exit 1
+          fi
+          if [[ "$release_version" != "3.0.1.118021" || "${{ steps.route.outputs.target_branch }}" != "master-1.18" ]]; then
+            echo "This dispatcher revision is sealed for Base Metals 3.0.1.118021 from master-1.18" >&2
+            exit 1
+          fi
+
+          release_sha="$(git rev-parse HEAD)"
+          release_tag="$release_version"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "minecraft_version=$minecraft_version" >> "$GITHUB_OUTPUT"
+          echo "loader_name=$loader_name" >> "$GITHUB_OUTPUT"
+          echo "loader_display=$loader_display" >> "$GITHUB_OUTPUT"
+          echo "java_version=$java_version" >> "$GITHUB_OUTPUT"
+          echo "java_toolchain_version=$java_toolchain_version" >> "$GITHUB_OUTPUT"
+          echo "gradle_java_version=$gradle_java_version" >> "$GITHUB_OUTPUT"
+          echo "curseforge_project_id=$curseforge_project_id" >> "$GITHUB_OUTPUT"
+          echo "main_jar=BaseMetals-$release_version.jar" >> "$GITHUB_OUTPUT"
+          echo "sources_jar=BaseMetals-$release_version-sources.jar" >> "$GITHUB_OUTPUT"
+          echo "javadoc_jar=BaseMetals-$release_version-javadoc.jar" >> "$GITHUB_OUTPUT"
+
+          successful_ci="$(gh api \
+            "repos/$GITHUB_REPOSITORY/commits/$release_sha/check-runs?per_page=100" \
+            --jq '[.check_runs[] | select(.name == "Build, test, and audit" and .conclusion == "success")] | length')"
+          if [[ "$successful_ci" -lt 1 ]]; then
+            echo "The selected commit has no successful Build, test, and audit check" >&2
+            exit 1
+          fi
+
+          if tag_json="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$release_tag" 2>/dev/null)"; then
+            tag_sha="$(jq -r '.object.sha' <<<"$tag_json")"
+            if [[ "$tag_sha" != "$release_sha" ]]; then
+              echo "Existing tag $release_tag resolves to $tag_sha instead of $release_sha" >&2
+              exit 1
+            fi
+          fi
+
+  build:
+    name: Build immutable release artifact
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      MAIN_JAR: ${{ needs.preflight.outputs.main_jar }}
+      SOURCES_JAR: ${{ needs.preflight.outputs.sources_jar }}
+      JAVADOC_JAR: ${{ needs.preflight.outputs.javadoc_jar }}
+    outputs:
+      artifact_name: ${{ steps.artifact.outputs.name }}
+
+    steps:
+      - name: Check out validated release ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.preflight.outputs.release_sha }}
+
+      - name: Install target Java toolchain
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: ${{ needs.preflight.outputs.java_toolchain_version }}
+
+      - name: Install Java for Gradle
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: ${{ needs.preflight.outputs.gradle_java_version }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+
+      - name: Stage exact OreSpawn release dependency
+        id: orespawn
+        run: |
+          mirror="$RUNNER_TEMP/orespawn-mirror"
+          bash gradle/stage-orespawn-release.sh "$mirror"
+          echo "repository=$mirror" >> "$GITHUB_OUTPUT"
+
+      - name: Build, test, and audit once
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean check build javadoc verifyReleaseArtifacts writeReleaseChecksums \
+            -PorespawnVerificationRepository="${{ steps.orespawn.outputs.repository }}" \
+            --no-daemon --stacktrace
+
+      - name: Stage the immutable release artifact
+        id: artifact
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/release-bundle"
+          mkdir -p "$bundle"
+          cp "build/libs/$MAIN_JAR" "$bundle/"
+          cp "build/libs/$SOURCES_JAR" "$bundle/"
+          cp "build/libs/$JAVADOC_JAR" "$bundle/"
+          cp build/release/SHA256SUMS "$bundle/"
+          cp CHANGELOG.txt "$bundle/"
+          (cd "$bundle" && sha256sum --check SHA256SUMS)
+          echo "name=BaseMetals-${{ needs.preflight.outputs.minecraft_version }}-${{ needs.preflight.outputs.loader_name }}-${{ needs.preflight.outputs.release_sha }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          if-no-files-found: error
+          retention-days: 90
+          path: ${{ runner.temp }}/release-bundle/*
+
+      - name: Summarize the prepared release candidate
+        env:
+          RELEASE_BRANCH: ${{ needs.preflight.outputs.target_branch }}
+          RELEASE_LEVEL: ${{ inputs.curseforge_release_level }}
+          RELEASE_SHA: ${{ needs.preflight.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.preflight.outputs.release_version }}
+        run: |
+          {
+            echo "## Prepared release candidate"
+            echo
+            echo "- Version: \`$RELEASE_VERSION\`"
+            echo "- Target branch: \`$RELEASE_BRANCH\`"
+            echo "- Commit: \`$RELEASE_SHA\`"
+            echo "- CurseForge release level: \`$RELEASE_LEVEL\`"
+            echo "- GitHub Release type: ordinary release"
+            echo
+            echo "### Public artifact checksums"
+            echo '```text'
+            cat build/release/SHA256SUMS
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release_confirmation:
+    name: Confirm ${{ inputs.release_version }} live publication
+    needs:
+      - preflight
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Confirm publication and release-secret access
+        env:
+          CONFIRM_LIVE_PUBLICATION: ${{ inputs.confirm_live_publication }}
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+          MAVEN_UPLOAD_URL: ${{ secrets.MAVEN_UPLOAD_URL }}
+          MAVEN_UPLOAD_USERNAME: ${{ secrets.MAVEN_UPLOAD_USERNAME }}
+          MAVEN_UPLOAD_PASSWORD: ${{ secrets.MAVEN_UPLOAD_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [[ "$CONFIRM_LIVE_PUBLICATION" != "true" ]]; then
+            echo "Confirm live publication in the workflow form before releasing ${{ needs.preflight.outputs.release_tag }}" >&2
+            exit 1
+          fi
+          echo "Live publication confirmed for ${{ needs.preflight.outputs.release_tag }}"
+          missing=()
+          for name in CURSEFORGE_TOKEN MAVEN_UPLOAD_URL MAVEN_UPLOAD_USERNAME MAVEN_UPLOAD_PASSWORD; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Required release secret is unavailable: %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+          echo "All four required release secrets are available."
+
+  create_release_tag:
+    name: Create validated release tag
+    needs:
+      - preflight
+      - build
+      - release_confirmation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - name: Create or verify the exact tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.preflight.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          if tag_json="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" 2>/dev/null)"; then
+            tag_sha="$(jq -r '.object.sha' <<<"$tag_json")"
+            if [[ "$tag_sha" != "$RELEASE_SHA" ]]; then
+              echo "Existing tag $RELEASE_TAG resolves to $tag_sha instead of $RELEASE_SHA" >&2
+              exit 1
+            fi
+            echo "Existing tag $RELEASE_TAG already points to $RELEASE_SHA"
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$RELEASE_TAG" \
+              -f sha="$RELEASE_SHA" >/dev/null
+            echo "Created tag $RELEASE_TAG at $RELEASE_SHA"
+          fi
+
+          created_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq '.object.sha')"
+          if [[ "$created_sha" != "$RELEASE_SHA" ]]; then
+            echo "Tag verification returned $created_sha instead of $RELEASE_SHA" >&2
+            exit 1
+          fi
+
+  publish_maven:
+    name: Publish Maven
+    needs:
+      - preflight
+      - build
+      - create_release_tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out the tagged publication definition
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.preflight.outputs.release_sha }}
+
+      - name: Install target Java toolchain
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: ${{ needs.preflight.outputs.java_toolchain_version }}
+
+      - name: Install Java for Gradle
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: ${{ needs.preflight.outputs.gradle_java_version }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+
+      - name: Download immutable release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ${{ runner.temp }}/release-input
+
+      - name: Verify artifact and Maven credentials
+        env:
+          MAVEN_UPLOAD_URL: ${{ secrets.MAVEN_UPLOAD_URL }}
+          MAVEN_UPLOAD_USERNAME: ${{ secrets.MAVEN_UPLOAD_USERNAME }}
+          MAVEN_UPLOAD_PASSWORD: ${{ secrets.MAVEN_UPLOAD_PASSWORD }}
+        run: |
+          set -euo pipefail
+          (cd "$RUNNER_TEMP/release-input" && sha256sum --check SHA256SUMS)
+          if [[ -z "$MAVEN_UPLOAD_URL" || -z "$MAVEN_UPLOAD_USERNAME" || -z "$MAVEN_UPLOAD_PASSWORD" ]]; then
+            echo "Maven upload URL and credentials must all be configured" >&2
+            exit 1
+          fi
+          if [[ "$MAVEN_UPLOAD_URL" == file:* ]]; then
+            echo "Maven publication cannot target a runner-local repository" >&2
+            exit 1
+          fi
+
+      - name: Publish the prepared Maven artifacts
+        env:
+          MAVEN_UPLOAD_URL: ${{ secrets.MAVEN_UPLOAD_URL }}
+          MAVEN_UPLOAD_USERNAME: ${{ secrets.MAVEN_UPLOAD_USERNAME }}
+          MAVEN_UPLOAD_PASSWORD: ${{ secrets.MAVEN_UPLOAD_PASSWORD }}
+        run: |
+          chmod +x ./gradlew
+          ./gradlew publishMavenJavaPublicationToReleaseRepository \
+            -PpreparedReleaseDir="$RUNNER_TEMP/release-input" \
+            --no-daemon --stacktrace
+
+  publish_curseforge:
+    name: Publish CurseForge
+    needs:
+      - preflight
+      - build
+      - publish_maven
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Download immutable release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ${{ runner.temp }}/release-input
+
+      - name: Verify artifact and CurseForge credential
+        env:
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+        run: |
+          set -euo pipefail
+          (cd "$RUNNER_TEMP/release-input" && sha256sum --check SHA256SUMS)
+          if [[ -z "$CURSEFORGE_TOKEN" ]]; then
+            echo "CURSEFORGE_TOKEN must be configured" >&2
+            exit 1
+          fi
+
+      - name: Publish Base Metals
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
+        with:
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          curseforge-id: ${{ needs.preflight.outputs.curseforge_project_id }}
+          name: Base Metals ${{ needs.preflight.outputs.release_version }} for Minecraft ${{ needs.preflight.outputs.minecraft_version }} (${{ needs.preflight.outputs.loader_display }})
+          version: ${{ needs.preflight.outputs.release_version }}
+          version-type: ${{ inputs.curseforge_release_level }}
+          changelog-file: ${{ runner.temp }}/release-input/CHANGELOG.txt
+          loaders: ${{ needs.preflight.outputs.loader_name }}
+          game-versions: ${{ needs.preflight.outputs.minecraft_version }}
+          game-version-filter: none
+          environment: client | server
+          java: Java ${{ needs.preflight.outputs.java_version }}
+          curseforge-dependencies: 245586(required)
+          fail-mode: fail
+          files: |
+            ${{ runner.temp }}/release-input/${{ needs.preflight.outputs.main_jar }}
+            ${{ runner.temp }}/release-input/${{ needs.preflight.outputs.sources_jar }}
+            ${{ runner.temp }}/release-input/${{ needs.preflight.outputs.javadoc_jar }}
+
+  publish_github:
+    name: Publish GitHub Release
+    needs:
+      - preflight
+      - build
+      - publish_curseforge
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - name: Download immutable release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ${{ runner.temp }}/release-input
+
+      - name: Verify artifact
+        run: (cd "$RUNNER_TEMP/release-input" && sha256sum --check SHA256SUMS)
+
+      - name: Publish GitHub Release last
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
+        with:
+          github-token: ${{ github.token }}
+          github-tag: ${{ needs.preflight.outputs.release_tag }}
+          github-commitish: ${{ needs.preflight.outputs.release_sha }}
+          github-draft: false
+          github-prerelease: false
+          name: Base Metals ${{ needs.preflight.outputs.release_version }} for Minecraft ${{ needs.preflight.outputs.minecraft_version }} (${{ needs.preflight.outputs.loader_display }})
+          version: ${{ needs.preflight.outputs.release_version }}
+          version-type: release
+          changelog-file: ${{ runner.temp }}/release-input/CHANGELOG.txt
+          fail-mode: fail
+          files: |
+            ${{ runner.temp }}/release-input/${{ needs.preflight.outputs.main_jar }}
+            ${{ runner.temp }}/release-input/${{ needs.preflight.outputs.sources_jar }}
+            ${{ runner.temp }}/release-input/${{ needs.preflight.outputs.javadoc_jar }}
+            ${{ runner.temp }}/release-input/SHA256SUMS

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -47,7 +47,9 @@ jobs:
       loader_display: ${{ steps.validate.outputs.loader_display }}
       java_version: ${{ steps.validate.outputs.java_version }}
       java_toolchain_version: ${{ steps.validate.outputs.java_toolchain_version }}
+      java_setup_version: ${{ steps.validate.outputs.java_setup_version }}
       gradle_java_version: ${{ steps.validate.outputs.gradle_java_version }}
+      install_gradle_java: ${{ steps.validate.outputs.install_gradle_java }}
       curseforge_project_id: ${{ steps.validate.outputs.curseforge_project_id }}
       main_jar: ${{ steps.validate.outputs.main_jar }}
       sources_jar: ${{ steps.validate.outputs.sources_jar }}
@@ -137,6 +139,7 @@ jobs:
           loader_code="$(value loader_code)"
           java_version="$(value java_version)"
           java_toolchain_version="$(value java_toolchain_version)"
+          java_setup_version="$(value java_setup_version)"
           gradle_java_version="$(value gradle_java_version)"
           curseforge_project_id="$(value curseforge_project_id)"
 
@@ -148,6 +151,53 @@ jobs:
             fi
           done
           java_toolchain_version="${java_toolchain_version:-$java_version}"
+          java_setup_version="${java_setup_version:-$java_toolchain_version}"
+
+          java_major() {
+            local version="$1"
+            if [[ ! "$version" =~ ^([0-9]+)([._+-].*)?$ ]]; then
+              echo "Invalid Java toolchain version $version" >&2
+              return 1
+            fi
+            printf '%s' "${BASH_REMATCH[1]}"
+          }
+          requires_separate_gradle_java() {
+            local toolchain_major
+            toolchain_major="$(java_major "$1")"
+            [[ "$toolchain_major" != "$2" ]]
+          }
+
+          if [[ "$(java_major "$java_setup_version")" != "$(java_major "$java_toolchain_version")" ]]; then
+            echo "Hosted Java selector $java_setup_version does not match toolchain $java_toolchain_version" >&2
+            exit 1
+          fi
+
+          java_setup_contracts=(
+            '8.0.502+7 17 true'
+            '16.0.2+7 17 true'
+            '17.0.1+12 17 false'
+            '17 17 false'
+            '21.0.8+9 21 false'
+          )
+          for contract in "${java_setup_contracts[@]}"; do
+            read -r contract_toolchain contract_gradle expected <<<"$contract"
+            actual=false
+            if requires_separate_gradle_java "$contract_toolchain" "$contract_gradle"; then
+              actual=true
+            fi
+            if [[ "$actual" != "$expected" ]]; then
+              echo "Java setup contract failed for toolchain $contract_toolchain and Gradle $contract_gradle" >&2
+              exit 1
+            fi
+          done
+
+          install_gradle_java=false
+          if requires_separate_gradle_java "$java_toolchain_version" "$gradle_java_version"; then
+            install_gradle_java=true
+            echo "Gradle Java $gradle_java_version will be installed separately from toolchain $java_toolchain_version"
+          else
+            echo "Pinned toolchain $java_toolchain_version also satisfies Gradle Java $gradle_java_version"
+          fi
 
           IFS=. read -r mc_major mc_minor mc_patch extra <<<"$minecraft_version"
           if [[ -n "${extra:-}" || -z "${mc_major:-}" || -z "${mc_minor:-}" ]]; then
@@ -184,8 +234,8 @@ jobs:
             echo "Requested version $REQUESTED_VERSION does not match ${{ steps.route.outputs.target_branch }} mod_version $release_version" >&2
             exit 1
           fi
-          if [[ "$release_version" != "3.0.1.118021" || "${{ steps.route.outputs.target_branch }}" != "master-1.18" ]]; then
-            echo "This dispatcher revision is sealed for Base Metals 3.0.1.118021 from master-1.18" >&2
+          if [[ "${{ steps.route.outputs.target_branch }}" != "master-1.18" ]]; then
+            echo "This dispatcher supports Base Metals 1.18.2 releases from master-1.18" >&2
             exit 1
           fi
 
@@ -199,7 +249,9 @@ jobs:
           echo "loader_display=$loader_display" >> "$GITHUB_OUTPUT"
           echo "java_version=$java_version" >> "$GITHUB_OUTPUT"
           echo "java_toolchain_version=$java_toolchain_version" >> "$GITHUB_OUTPUT"
+          echo "java_setup_version=$java_setup_version" >> "$GITHUB_OUTPUT"
           echo "gradle_java_version=$gradle_java_version" >> "$GITHUB_OUTPUT"
+          echo "install_gradle_java=$install_gradle_java" >> "$GITHUB_OUTPUT"
           echo "curseforge_project_id=$curseforge_project_id" >> "$GITHUB_OUTPUT"
           echo "main_jar=BaseMetals-$release_version.jar" >> "$GITHUB_OUTPUT"
           echo "sources_jar=BaseMetals-$release_version-sources.jar" >> "$GITHUB_OUTPUT"
@@ -239,13 +291,24 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.release_sha }}
 
+      - name: Install pinned Java 25 Mavenizer runtime
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '25.0.3+9.0.LTS'
+
       - name: Install target Java toolchain
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: ${{ needs.preflight.outputs.java_toolchain_version }}
+          java-version: ${{ needs.preflight.outputs.java_setup_version }}
 
-      - name: Install Java for Gradle
+      - name: Record target Java toolchain path
+        shell: bash
+        run: echo "BASEMETALS_TARGET_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Install separate Java for Gradle
+        if: needs.preflight.outputs.install_gradle_java == 'true'
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
@@ -253,6 +316,26 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+
+      - name: Resolve explicit Gradle Java installations
+        id: java-paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=(
+            "$JAVA_HOME_25_X64"
+            "$BASEMETALS_TARGET_JAVA_HOME"
+            "$JAVA_HOME"
+          )
+          paths=
+          for candidate in "${candidates[@]}"; do
+            test -x "$candidate/bin/java"
+            canonical="$(cd "$candidate" && pwd -P)"
+            if [[ ",$paths," != *",$canonical,"* ]]; then
+              paths="${paths:+$paths,}$canonical"
+            fi
+          done
+          echo "paths=$paths" >> "$GITHUB_OUTPUT"
 
       - name: Stage exact OreSpawn release dependency
         id: orespawn
@@ -263,10 +346,16 @@ jobs:
 
       - name: Build, test, and audit once
         run: |
+          set -euo pipefail
           chmod +x ./gradlew
+          java_args=(
+            "-Dorg.gradle.java.installations.paths=${{ steps.java-paths.outputs.paths }}"
+            -Dorg.gradle.java.installations.auto-detect=false
+            -Dorg.gradle.java.installations.auto-download=false
+          )
           ./gradlew clean check build javadoc verifyReleaseArtifacts writeReleaseChecksums \
             -PorespawnVerificationRepository="${{ steps.orespawn.outputs.repository }}" \
-            --no-daemon --stacktrace
+            --no-daemon --stacktrace "${java_args[@]}"
 
       - name: Stage the immutable release artifact
         id: artifact
@@ -402,13 +491,24 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.release_sha }}
 
+      - name: Install pinned Java 25 Mavenizer runtime
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '25.0.3+9.0.LTS'
+
       - name: Install target Java toolchain
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: ${{ needs.preflight.outputs.java_toolchain_version }}
+          java-version: ${{ needs.preflight.outputs.java_setup_version }}
 
-      - name: Install Java for Gradle
+      - name: Record target Java toolchain path
+        shell: bash
+        run: echo "BASEMETALS_TARGET_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Install separate Java for Gradle
+        if: needs.preflight.outputs.install_gradle_java == 'true'
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
@@ -416,6 +516,26 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+
+      - name: Resolve explicit Gradle Java installations
+        id: java-paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=(
+            "$JAVA_HOME_25_X64"
+            "$BASEMETALS_TARGET_JAVA_HOME"
+            "$JAVA_HOME"
+          )
+          paths=
+          for candidate in "${candidates[@]}"; do
+            test -x "$candidate/bin/java"
+            canonical="$(cd "$candidate" && pwd -P)"
+            if [[ ",$paths," != *",$canonical,"* ]]; then
+              paths="${paths:+$paths,}$canonical"
+            fi
+          done
+          echo "paths=$paths" >> "$GITHUB_OUTPUT"
 
       - name: Download immutable release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -449,7 +569,10 @@ jobs:
           chmod +x ./gradlew
           ./gradlew publishMavenJavaPublicationToReleaseRepository \
             -PpreparedReleaseDir="$RUNNER_TEMP/release-input" \
-            --no-daemon --stacktrace
+            --no-daemon --stacktrace \
+            -Dorg.gradle.java.installations.paths="${{ steps.java-paths.outputs.paths }}" \
+            -Dorg.gradle.java.installations.auto-detect=false \
+            -Dorg.gradle.java.installations.auto-download=false
 
   publish_curseforge:
     name: Publish CurseForge


### PR DESCRIPTION
## Summary

- add the default-branch **Release Base Metals** manual dispatcher so it appears in the MMD repository Actions UI
- derive and validate the release branch from the four-component target version, currently routing `3.0.1.118021` to `master-1.18`
- require the canonical repository, Base Metals CurseForge project, exact release metadata, an unused or matching tag, and a successful `Build, test, and audit` check on the selected commit
- install the exact Java 17 product toolchain and pinned Java 25 Mavenizer runtime, then disable implicit Java discovery and downloads
- build one checksummed immutable bundle and publish it in the guarded Maven -> CurseForge -> GitHub order only after explicit live-publication confirmation
- publish Base Metals with OreSpawn project `245586` declared as a required CurseForge dependency

GitHub exposes `workflow_dispatch` actions from the repository default branch, so this deliberately targets `master-1.12` while checking out and releasing `master-1.18`.

## Validation

- actionlint `1.7.12`
- all external actions use the same commit-pinned revisions as OreSpawn's canonical dispatcher
- static release-contract checks for repository identity, branch routing, toolchains, secrets, artifact names, dependency declaration, and publication ordering
- live read-only preflight against MMD `master-1.18` at `3f12111edd9720bef4f58ff16c7a078af2c9287a`: version `3.0.1.118021`, target `118021`, CurseForge project `240967`, no existing release tag, and successful CI/CodeQL/wrapper checks

No dispatcher was run and nothing was tagged or published.