### PR TITLE
Install Java 8 for release launcher tasks

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -297,6 +297,12 @@ jobs:
           distribution: temurin
           java-version: '25.0.3+9.0.LTS'
 
+      - name: Install pinned Java 8 launcher toolchain
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '8.0.502+7'
+
       - name: Install target Java toolchain
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
@@ -324,6 +330,7 @@ jobs:
           set -euo pipefail
           candidates=(
             "$JAVA_HOME_25_X64"
+            "$JAVA_HOME_8_X64"
             "$BASEMETALS_TARGET_JAVA_HOME"
             "$JAVA_HOME"
           )
@@ -497,6 +504,12 @@ jobs:
           distribution: temurin
           java-version: '25.0.3+9.0.LTS'
 
+      - name: Install pinned Java 8 launcher toolchain
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '8.0.502+7'
+
       - name: Install target Java toolchain
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
@@ -524,6 +537,7 @@ jobs:
           set -euo pipefail
           candidates=(
             "$JAVA_HOME_25_X64"
+            "$JAVA_HOME_8_X64"
             "$BASEMETALS_TARGET_JAVA_HOME"
             "$JAVA_HOME"
           )


### PR DESCRIPTION
## Summary

- install pinned Temurin `8.0.502+7` in the immutable-build job
- include `JAVA_HOME_8_X64` in Gradle's explicit, auto-provisioning-disabled toolchain path
- mirror the same setup in the Maven publication job so release configuration remains reproducible after the bundle is built

## Root cause

[Release run 34234545497](https://github.com/MinecraftModDevelopmentMods/BaseMetals/actions/runs/34234545497/job/102088831134) correctly installed Java 17 and the Java 25 Mavenizer runtime, then failed while creating `runData` because ForgeGradle/Renamer's `SlimeLauncherExec` requires a Java 8 launcher. Automatic toolchain provisioning was deliberately disabled, and Java 8 was absent from the sealed path.

The fix matches OreSpawn's canonical default-branch dispatcher while retaining Java 17 as Base Metals' Gradle/product runtime and Java 25 for the Mavenizer.

## Validation

- actionlint `1.7.12`
- targeted contract check requires exactly two pinned Java 8 setup steps and two `JAVA_HOME_8_X64` path entries
- compared the setup and version pin against the successful canonical OreSpawn dispatcher
- `git diff --check`

The failed run never reached confirmation, tagging, Maven, CurseForge, or GitHub publication. This PR does not rerun the dispatcher or publish anything.